### PR TITLE
YALB-489: Wire Alerts

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -10,6 +10,10 @@ accordion:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/accordion/accordion.js: {}
 
+alert:
+  js:
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/alert/alert.js: {}
+
 primary-nav:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/primary-nav/primary-nav.js: {}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -1,3 +1,4 @@
+{{ elements.alert_block }}
 {% embed "@organisms/site-header/site-header.twig" with {
   site_name: site_name,
   site_header__border_thickness: '8',

--- a/templates/ys/ys-alert.html.twig
+++ b/templates/ys/ys-alert.html.twig
@@ -1,15 +1,4 @@
-{{ dd() }}
-
-<div class="alert-wrapper">
-  Available fields are:<br/>
-  Alert id: {{ id }}<br/>
-  Alert status: {{ status }}<br/>
-  Alert type: {{ type }}<br/>
-  Alert headline: {{ headline }}<br/>
-  Alert message: {{ message }}<br/>
-  Alert link title: {{ link_title }}<br/>
-  Alert link url: {{ link_url }}
-</div>
+{{ attach_library('atomic/alert' )}}
 
 {% include "@molecules/alert/alert.twig" with {
   alert__id: id,

--- a/templates/ys/ys-alert.html.twig
+++ b/templates/ys/ys-alert.html.twig
@@ -1,0 +1,21 @@
+{{ dd() }}
+
+<div class="alert-wrapper">
+  Available fields are:<br/>
+  Alert id: {{ id }}<br/>
+  Alert status: {{ status }}<br/>
+  Alert type: {{ type }}<br/>
+  Alert headline: {{ headline }}<br/>
+  Alert message: {{ message }}<br/>
+  Alert link title: {{ link_title }}<br/>
+  Alert link url: {{ link_url }}
+</div>
+
+{% include "@molecules/alert/alert.twig" with {
+  alert__id: id,
+  alert__type: type,
+  alert__heading: headline,
+  alert__content: message,
+  alert__link__content: link_title,
+  alert__link__url: link_url,
+} %}


### PR DESCRIPTION
## [YALB-489: Wire Alerts](https://yaleits.atlassian.net/browse/YALB-489)

### Description of work
- Wires the alert block and places it in the header
- Create and attach library for alert JS

### Functional testing steps:
- [ ] View the site, and verify there are no alerts.
- [ ] Log in, and go to the "YaleSites -> Alert Settings" page
	- [ ] Enable the alert, and fill in any/all fields
	- [ ] Save, and view the site. Verify the alert shows above the site header.
- [ ] Interact with the alert (close or collapse it) then refresh the page, and/or navigate to another page and verify the alert maintains its state (closed, collapsed, or expanded).
	- [ ] Open Chrome Dev Tools and go to the "Application -> Local Storage" section.
	- [ ] Verify there's an item for `ys-alert-id-XXX` (where XXX is a timestamp (to get unique IDs))
- [ ] Go back to the alert settings page and change the type, or any of the fields, and save.
	- [ ] Return to the site and verify a new alert is displayed in the "Expanded" state. (Don't interact with it yet)
	- [ ] Check the localStorage again, and verify the old ID is gone (There should be no alert ids in local storage)
- [ ] Interact with the new alert, and verify its ID and state is saved in local storage