### PR TITLE
YALB-521: Wire Pop-out Image

### DIFF
--- a/templates/paragraphs/paragraph--pop-out-image.html.twig
+++ b/templates/paragraphs/paragraph--pop-out-image.html.twig
@@ -1,0 +1,7 @@
+{% embed "@molecules/pop-out-image/pop-out-image.twig" with {
+  pop_out_image__content: content.field_text.0,
+} %}
+  {% block pop_out_image__image %}
+    {{ content.field_image }}
+  {% endblock %}
+{% endembed %}


### PR DESCRIPTION
## [YALB-521: Wire pop-out-image](https://yaleits.atlassian.net/browse/YALB-521)

## Related to the following PRs:
- https://github.com/yalesites-org/yalesites-project/pull/15
- https://github.com/yalesites-org/component-library-twig/pull/80

### Description of work
- Wires the Pop-out Image paragraph

### Functional testing steps:
- [ ] Follow the steps here: https://github.com/yalesites-org/yalesites-project/pull/15

## Notes:
- We're not currently providing a caption field. We should figure out how we want to capture that information.