### PR TITLE
YALB-495: Wire event paragraphs

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -19,3 +19,7 @@ alert:
 primary-nav:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/primary-nav/primary-nav.js: {}
+
+reference-card:
+  js:
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/cards/reference-card/reference-card.js: {}

--- a/atomic.theme
+++ b/atomic.theme
@@ -27,3 +27,29 @@ function atomic_preprocess_menu(&$variables, $hook) {
     }
   }
 }
+
+/**
+ * Implements hook_theme_suggestions_alter() for containers.
+ */
+function atomic_theme_suggestions_container_alter(array &$suggestions, array &$variables) {
+  $type = '';
+  $name = '';
+
+  if (isset($variables['element']['#type'])) {
+    // Get the element type.
+    $type = $variables['element']['#type'];
+
+    if (isset($variables['element']['#name'])) {
+      // Get the element name.
+      $name = $variables['element']['#name'];
+
+      // If both type and name are defined, create a suggestion with both.
+      array_unshift($suggestions, 'container__' . $type . '__' . $name);
+    }
+
+    // If type is defined, but not a generic "container" create a suggestion for the type.
+    if ($type !== 'container') {
+      array_unshift($suggestions, 'container__' . $type);
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1234,9 +1234,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.12.1",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.12.1/b7f29f838dab2821a08e1d601d2ebe3debe4e2714db3229dcb777d81ff08e8cd",
-      "integrity": "sha512-H3C1r1AbPHytk5t17Gqj9Yv/2ecKYirddcYkeijH9OrR7NIgn4p43GKcTChfk9oX0I+fjX3YieXhxhQuh1ELXA==",
+      "version": "1.12.2",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.12.2/6e4a49a6c6890b612ded2854e9a87805539ce1b5cfc716106139baa3dab1ab6e",
+      "integrity": "sha512-2ZZpeAh4ksyZa/b9qiJKo8cFV4bk/H7OZhnDIazo/WxJxwqqRpgF6iPCPMNrp4GUKAHcmoPAqquHr0eGbmzaLw==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {
@@ -18953,9 +18953,9 @@
       "version": "4.2.2"
     },
     "@yalesites-org/component-library-twig": {
-      "version": "1.12.1",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.12.1/b7f29f838dab2821a08e1d601d2ebe3debe4e2714db3229dcb777d81ff08e8cd",
-      "integrity": "sha512-H3C1r1AbPHytk5t17Gqj9Yv/2ecKYirddcYkeijH9OrR7NIgn4p43GKcTChfk9oX0I+fjX3YieXhxhQuh1ELXA==",
+      "version": "1.12.2",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.12.2/6e4a49a6c6890b612ded2854e9a87805539ce1b5cfc716106139baa3dab1ab6e",
+      "integrity": "sha512-2ZZpeAh4ksyZa/b9qiJKo8cFV4bk/H7OZhnDIazo/WxJxwqqRpgF6iPCPMNrp4GUKAHcmoPAqquHr0eGbmzaLw==",
       "requires": {
         "@storybook/storybook-deployer": "^2.8.11",
         "@yalesites-org/tokens": "^1.17.4",

--- a/templates/field/field--field-teaser-title.html.twig
+++ b/templates/field/field--field-teaser-title.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/templates/form/container--view.html.twig
+++ b/templates/form/container--view.html.twig
@@ -1,5 +1,5 @@
 {#
- # Remove wrapping div from all containers by default.
+ # Remove wrapping div from all view containers by default.
  # For the default template, see `web/core/themes/stabel9/templates/form/container.html.twig`.
  #}
 

--- a/templates/form/container.html.twig
+++ b/templates/form/container.html.twig
@@ -1,0 +1,6 @@
+{#
+ # Remove wrapping div from all containers by default.
+ # For the default template, see `web/core/themes/stabel9/templates/form/container.html.twig`.
+ #}
+
+{{ children }}

--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -1,0 +1,27 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set date__formatted %}
+  {% include "@atoms/date-time/date-time.twig" with {
+    date_time__start: content.field_event_date.0.start_time['#markup'],
+  } %}
+{% endset %}
+
+{% if content.field_event_format %}
+  {% set reference_card__overline %}
+    {% include "@molecules/cards/reference-card/event/_event-format.twig" with {
+      format: content.field_event_format,
+    } %}
+  {% endset %}
+{% endif %}
+
+{% embed "@molecules/cards/reference-card/reference-card.twig" with {
+  reference_card__heading: content.field_teaser_title,
+  reference_card__subheading: date__formatted,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image: 'true',
+} %}
+  {% block reference_card__image %}
+    {{ content.field_teaser_media }}
+  {% endblock %}
+{% endembed %}

--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -7,11 +7,11 @@
 {% endset %}
 
 {% if content.field_event_format %}
-  {% set reference_card__overline %}
+  {% set reference_card__overline -%}
     {% include "@molecules/cards/reference-card/event/_event-format.twig" with {
       format: content.field_event_format,
     } %}
-  {% endset %}
+  {%- endset %}
 {% endif %}
 
 {% embed "@molecules/cards/reference-card/reference-card.twig" with {

--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -14,8 +14,10 @@
   {%- endset %}
 {% endif %}
 
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+
 {% embed "@molecules/cards/reference-card/reference-card.twig" with {
-  reference_card__heading: content.field_teaser_title,
+  reference_card__heading: heading,
   reference_card__subheading: date__formatted,
   reference_card__url: url,
   reference_card__snippet: content.field_teaser_text,

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -7,15 +7,17 @@
 {% endset %}
 
 {% if content.field_event_format %}
-  {% set reference_card__overline %}
+  {% set reference_card__overline -%}
     {% include "@molecules/cards/reference-card/event/_event-format.twig" with {
       format: content.field_event_format,
     } %}
-  {% endset %}
+  {%- endset %}
 {% endif %}
 
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+
 {% embed "@molecules/cards/reference-card/reference-card.twig" with {
-  reference_card__heading: content.field_teaser_title,
+  reference_card__heading: heading,
   reference_card__subheading: date__formatted,
   reference_card__url: url,
   reference_card__snippet: content.field_teaser_text,

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -1,0 +1,27 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set date__formatted %}
+  {% include "@atoms/date-time/date-time.twig" with {
+    date_time__start: content.field_event_date.0.start_time['#markup'],
+  } %}
+{% endset %}
+
+{% if content.field_event_format %}
+  {% set reference_card__overline %}
+    {% include "@molecules/cards/reference-card/event/_event-format.twig" with {
+      format: content.field_event_format,
+    } %}
+  {% endset %}
+{% endif %}
+
+{% embed "@molecules/cards/reference-card/reference-card.twig" with {
+  reference_card__heading: content.field_teaser_title,
+  reference_card__subheading: date__formatted,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image: 'true',
+} %}
+  {% block reference_card__image %}
+    {{ content.field_teaser_media }}
+  {% endblock %}
+{% endembed %}

--- a/templates/paragraphs/paragraph--event-cards.html.twig
+++ b/templates/paragraphs/paragraph--event-cards.html.twig
@@ -1,8 +1,12 @@
-{% embed "@organisms/card-collection/card-collection.twig" with {
-  card_collection__heading: content.field_heading,
-  card_collection__featured: 'false',
-} %}
-  {% block card_collection__cards %}
-    {{ drupal_view('event_cards', 'full') }}
-  {% endblock %}
-{% endembed %}
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% embed "@organisms/card-collection/card-collection.twig" with {
+    card_collection__heading: content.field_heading,
+    card_collection__featured: 'false',
+  } %}
+    {% block card_collection__cards %}
+      {{ drupal_view('event_cards', 'full') }}
+    {% endblock %}
+  {% endembed %}
+</div>

--- a/templates/paragraphs/paragraph--event-cards.html.twig
+++ b/templates/paragraphs/paragraph--event-cards.html.twig
@@ -1,0 +1,8 @@
+{% embed "@organisms/card-collection/card-collection.twig" with {
+  card_collection__heading: content.field_heading,
+  card_collection__featured: 'false',
+} %}
+  {% block card_collection__cards %}
+    {{ drupal_view('event_cards', 'full') }}
+  {% endblock %}
+{% endembed %}

--- a/templates/paragraphs/paragraph--event-list.html.twig
+++ b/templates/paragraphs/paragraph--event-list.html.twig
@@ -1,0 +1,9 @@
+{% embed "@organisms/card-collection/card-collection.twig" with {
+  card_collection__heading: content.field_heading,
+  card_collection__featured: 'false',
+  card_collection__type: 'list',
+} %}
+  {% block card_collection__cards %}
+    {{ drupal_view('event_list', 'full') }}
+  {% endblock %}
+{% endembed %}

--- a/templates/paragraphs/paragraph--event-list.html.twig
+++ b/templates/paragraphs/paragraph--event-list.html.twig
@@ -1,9 +1,13 @@
-{% embed "@organisms/card-collection/card-collection.twig" with {
-  card_collection__heading: content.field_heading,
-  card_collection__featured: 'false',
-  card_collection__type: 'list',
-} %}
-  {% block card_collection__cards %}
-    {{ drupal_view('event_list', 'full') }}
-  {% endblock %}
-{% endembed %}
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% embed "@organisms/card-collection/card-collection.twig" with {
+    card_collection__heading: content.field_heading,
+    card_collection__featured: 'false',
+    card_collection__type: 'list',
+  } %}
+    {% block card_collection__cards %}
+      {{ drupal_view('event_list', 'full') }}
+    {% endblock %}
+  {% endembed %}
+</div>

--- a/templates/views/views-view-unformatted.html.twig
+++ b/templates/views/views-view-unformatted.html.twig
@@ -1,0 +1,11 @@
+{#
+ # Remove wrapping div from all containers by default.
+ # For the default template, see `web/core/themes/stabel9/templates/views/views-view-unformatted.html.twig`.
+ #}
+
+{% if title %}
+  <h3>{{ title }}</h3>
+{% endif %}
+{% for row in rows %}
+  {{- row.content -}}
+{% endfor %}

--- a/templates/views/views-view.html.twig
+++ b/templates/views/views-view.html.twig
@@ -1,0 +1,35 @@
+{#
+ # Remove wrapping div from all containers by default.
+ # For the default template, see `web/core/themes/stabel9/templates/views/views-view.html.twig`.
+ #}
+
+{{ title_prefix }}
+{{ title }}
+{{ title_suffix }}
+
+{% if header %}
+  <header>
+    {{ header }}
+  </header>
+{% endif %}
+
+{{ exposed }}
+{{ attachment_before }}
+
+{% if rows -%}
+  {{ rows }}
+{% elseif empty -%}
+  {{ empty }}
+{% endif %}
+{{ pager }}
+
+{{ attachment_after }}
+{{ more }}
+
+{% if footer %}
+  <footer>
+    {{ footer }}
+  </footer>
+{% endif %}
+
+{{ feed_icons }}


### PR DESCRIPTION
## [YALB-495: Wire event paragraphs](https://yaleits.atlassian.net/browse/YALB-495)

### Description of work
- Creates a handful of "default templates" to remove unwanted wrappers added by Stable9
- Wires the card and list view modes for events
- Wires the card and list views for events

### Functional testing steps:
- Follow the review steps here: https://github.com/yalesites-org/yalesites-project/pull/59