### PR TITLE
YALB-560: removes attribution dash

### DIFF
--- a/templates/paragraphs/paragraph--pull-quote.html.twig
+++ b/templates/paragraphs/paragraph--pull-quote.html.twig
@@ -1,8 +1,9 @@
+{{ dd(content.field_attribution.0) }}
 <div{{ attributes }}>
   {{ title_prefix }}
   {{ title_suffix }}
   {% include "@molecules/pull-quote/pull-quote.twig" with {
     pull_quote__quote: content.field_text,
-    pull_quote__attribution: content.field_attribution,
+    pull_quote__attribution: content.field_attribution.0,
   } %}
 </div>

--- a/templates/paragraphs/paragraph--pull-quote.html.twig
+++ b/templates/paragraphs/paragraph--pull-quote.html.twig
@@ -1,4 +1,3 @@
-{{ dd(content.field_attribution.0) }}
 <div{{ attributes }}>
   {{ title_prefix }}
   {{ title_suffix }}


### PR DESCRIPTION
## [YALB-560: removes attribution dash](https://yaleits.atlassian.net/browse/YALB-560)

### Description of work
- Fixes the attribution variable to no longer display a dash if no content is provided.

### Functional testing steps:
- [ ] Login to site.
- [ ] Navigate to content/page.
- [ ] Add a pull quote.
