### PR TITLE
YALB-585: Wire headline field to banners

### DIFF
--- a/templates/node/node--full.html.twig
+++ b/templates/node/node--full.html.twig
@@ -1,9 +1,9 @@
 {% if content.field_banner|render %}
   {{ content.field_banner }}
-{% else %}
-  {% include "@molecules/page-title/page-title.twig" with {
-    page_title__heading: label,
-  } %}
 {% endif %}
+
+{% include "@molecules/page-title/page-title.twig" with {
+  page_title__heading: label,
+} %}
 
 {{ content|without('field_banner') }}

--- a/templates/paragraphs/paragraph--cta-banner.html.twig
+++ b/templates/paragraphs/paragraph--cta-banner.html.twig
@@ -1,8 +1,6 @@
 <div{{ attributes }}>
-  {{ title_prefix }}
-  {{ title_suffix }}
   {% embed "@molecules/banner/cta/cta-banner.twig" with {
-    banner__heading: paragraph.parentEntity.title.value,
+    banner__heading: content.field_heading,
     banner__snippet: content.field_text,
     banner__link__content: content.field_link.0['#title'],
     banner__link__url: content.field_link.0['#url_title'],
@@ -10,5 +8,5 @@
     {% block banner__image %}
       {{ content.field_image }}
     {% endblock %}
-{% endembed %}
+  {% endembed %}
 </div>


### PR DESCRIPTION
## [YALB-585: Wire headline field to banners](https://yaleits.atlassian.net/browse/YALB-585)

### Description of work
- Removes conditional logic for displaying page title. The page title should always display even when pages have a banner.
- Wires the banner's heading field to the component. The node title will no longer display within the banner.

### Functional testing steps:
- [ ] Create a page.
  - [ ] Add a CTA banner paragraph within the 'content' field
  - [ ] Add a CTA banner paragraph within the 'banner' field
- [ ] Verify that the banner-banner appear above the page title
- [ ] Verify that the content-banner appears below the page title
- [ ] Verify that the banner heading fields display within the banner component.