### PR TITLE
YALB-237: Add theme settings to twig

### DIFF
--- a/templates/layout/region--footer.html.twig
+++ b/templates/layout/region--footer.html.twig
@@ -1,5 +1,6 @@
 {% embed "@organisms/site-footer/yds-site-footer.twig" with {
   site_footer__border_thickness: '8',
+  site_footer__theme: getThemeSetting('footer_theme'),
 } %}
   {% block site_footer__text %}{% endblock %}
   {% block site_footer__columns %}{% endblock %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -2,6 +2,8 @@
 {% embed "@organisms/site-header/yds-site-header.twig" with {
   site_name: site_name,
   site_header__border_thickness: '8',
+  site_header__theme: getThemeSetting('header_theme'),
+  site_header__nav_position: getThemeSetting('nav_position'),
 } %}
   {% block site_header__utility_nav %}
     {{ elements.utility_navigation }}


### PR DESCRIPTION
## [YALB-237: Theme Settings: Header, Footer, Nav settings](https://yaleits.atlassian.net/browse/YALB-237)

### Description of work
- Adds theme settings for header theme, footer theme, and navigation position into twig templates
- **Note**: until YALB-691 is merged in, the "Blue" setting won't work properly.

### Functional testing steps:
- [ ] Visit ```/admin/yalesites/themes``` and set the Navigation Position, Header Theme, and Footer Theme to one of the options. See note above about "Blue".
- [ ] Save the configuration
- [ ] Visit the front-end and verify that the header, footer, and navigation are updated to use the new settings.
- [ ] Change the values again and re-visit the front-end and verify that the settings are applied.
