### PR TITLE
YALB-502: Dynamic accordion heading level

### DIFF
--- a/templates/paragraphs/paragraph--accordion-item.html.twig
+++ b/templates/paragraphs/paragraph--accordion-item.html.twig
@@ -1,4 +1,5 @@
 {% include "@molecules/accordion/_accordion-item.twig" with {
   accordion__item__heading: content.field_heading,
   accordion__item__content: content.field_content,
+  accordion__item__heading__level: has_outer_heading ? 3 : 2
 } %}


### PR DESCRIPTION
## [YALB-502: Feedback: Accordion item heading level](https://yaleits.atlassian.net/browse/YALB-502)

### Description of work
- Allows for accordion items to have a dynamic heading level based on the parent accordion heading
- Adds logic for what heading level in ```paragraph--accordion-item.html.twig```

### Functional testing steps:
*Note:* These are the same steps as the PR-101 from yalesites-project.
- [ ] For this to work, [PR-101 from yalesites-project](https://github.com/yalesites-org/yalesites-project/pull/101) will need to be merged in.
- [ ] On the FAQ page (or create a new page with an accordion, accordion heading, and accordion items) - verify that the accordion item headings are h3 if the outside accordion heading exists.
- [ ] Edit the FAQ or the page just created and remove the outside accordion heading and save the page
- [ ] Verify that, without an outside accordion heading, the accordion internal headings have changed to h2.
