### PR TITLE
YALB-719: Add style variation to quick links

### DIFF
--- a/templates/paragraphs/paragraph--quick-links.html.twig
+++ b/templates/paragraphs/paragraph--quick-links.html.twig
@@ -1,11 +1,13 @@
 <div{{ attributes }}>
   {{ title_prefix }}
   {{ title_suffix }}
+
   {% embed "@molecules/quick-links/yds-quick-links.twig" with {
     quick_links__heading: content.field_heading.0['#text'],
     quick_links__description: content.field_text.0['#text'],
     quick_links__image: content.field_image.0,
     quick_links__links: content.field_links.0,
+    quick_links__variation: content.field_style_variation.0['#markup'],
   } %}
     {% block quick_links__links %}
       {{ content.field_links }}


### PR DESCRIPTION
## [YALB-719: Quick Links Subtle - Variation](https://yaleits.atlassian.net/browse/YALB-719)

### Description of work
- Adds quick links style variation to links field to correctly style links

### Functional testing steps:
- [ ] Note: [PR-105](https://github.com/yalesites-org/yalesites-project/pull/105) from yalesites-project is also part of this work
- [ ] Create a new page and add a quick links paragraph to the page
- [ ] Under the "Styles" tab, select "subtle" as the Style
- [ ] Save and view the page on the front-end
- [ ] Verify that the quick links style is the subtle variation
- [ ] Links will be styled correctly if PR-105 is merged in
