### PR TITLE
YALB-718: Fix start time typo

### DIFF
--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -3,7 +3,7 @@
 } %}
   {% block page_title__meta %}
     {% include "@molecules/meta/event-meta/yds-event-meta.twig" with {
-      event_meta__date_start: content.field_event_date.0.start_titme['#markup'],
+      event_meta__date_start: content.field_event_date.0.start_time['#markup'],
       event_meta__date_end: content.field_event_date.0.end_time['#markup'],
       event_meta__format: content.field_event_format,
       event_meta__address: nothing_yet,


### PR DESCRIPTION
## [YALB-718: Fix start time typo](https://yaleits.atlassian.net/browse/YALB-718)

### Description of work
- Fixes the start time bug

### Functional testing steps:
- [ ] Create an event with different start and end times, verify the start time is correct, and not using "today's date"

### Note:
- This does not address the "All day" checkbox in Drupal. That wasn't accounted for in design, and we should figure out what that should do on the frontend, or remove the checkbox from the backend.