### PR TITLE
YALB-700: Search Form

### DIFF
--- a/templates/form/form-element-label--search-form.html.twig
+++ b/templates/form/form-element-label--search-form.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override for a form element label.
+ *
+ * Available variables:
+ * - title: The label's text.
+ * - title_display: Elements title_display setting.
+ * - required: An indicator for whether the associated form element is required.
+ * - attributes: A list of HTML attributes for the label.
+ *
+ * @see template_preprocess_form_element_label()
+ */
+#}
+{%
+  set classes = [
+    title_display == 'after' ? 'option',
+    title_display == 'invisible' ? 'visually-hidden',
+    required ? 'js-form-required',
+    required ? 'form-required',
+  ]
+%}
+
+{% set utility_nav__base_class = 'utility-nav' %}
+
+{% if title is not empty or required -%}
+  <label{{ attributes.addClass(classes) }}>
+    {% include "@atoms/images/icons/_yds-icon.twig" with {
+      icon__name: 'magnifying-glass',
+      icon__blockname: utility_nav__base_class,
+      icon__modifiers: ['search'],
+      icon__decorative: true,
+    } %}
+    <span class="visually-hidden">{{ title }}</span>
+  </label>
+{%- endif %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -6,7 +6,14 @@
   site_header__nav_position: getThemeSetting('nav_position'),
 } %}
   {% block site_header__utility_nav %}
-    {{ elements.utility_navigation }}
+    {% embed "@organisms/menu/utility-nav/yds-utility-nav.twig" %}
+      {% block utility_nav__menu %}
+        {{ elements.utility_navigation }}
+      {% endblock %}
+      {% block site_header__search %}
+        {{ drupal_block('views_exposed_filter_block:search-page_1', {label_display: false}, false) }}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
   {% block site_header__primary_nav %}
     {{ elements.main_navigation }}

--- a/templates/navigation/menu--utility-navigation.html.twig
+++ b/templates/navigation/menu--utility-navigation.html.twig
@@ -1,1 +1,1 @@
-{% include "@organisms/menu/utility-nav/yds-utility-nav.twig" %}
+{% include "@organisms/menu/utility-nav/_utility-nav--menu.twig" %}


### PR DESCRIPTION
## [YALB-700: Search: Form component](https://yaleits.atlassian.net/browse/YALB-700)

### Description of work
- Adds a search form to the utility navigation area
- NOTE: This requires [PR-115](https://github.com/yalesites-org/yalesites-project/pull/115) from yalesites-project and [PR-147](https://github.com/yalesites-org/component-library-twig/pull/147) from component-library-twig

### Functional testing steps:
- [ ] Visit any page and verify that the search box is located in the utility menu area and is styled appropriately (See screenshot)

![Screen Shot 2022-09-22 at 10 56 36 AM](https://user-images.githubusercontent.com/107938318/191818158-f6bcd047-dba7-494b-9554-e18050e7dc08.png)
