### PR TITLE
YALB-702: Search: Hide search form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1234,9 +1234,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.15.2",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.15.2/defa43f7e4b9543a1c26dd6135fcb002d48f853e",
-      "integrity": "sha512-lcOb4ZMpJeikOrhXj+pEtxPyV3YpdWZfIE7l5JKPrk7x2NesS1C3gdPfdu9WSCGKtUlwqX5CWNcRvf7lB9N08w==",
+      "version": "1.17.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.17.0/3abaed9df8c6eda7d6fd209d6c6094f0b5757e4f",
+      "integrity": "sha512-4ESLqrOns0dyjy8uZAVNH71kWNIVhBFlq35nKhWpOFJpCv4CKj4TuYANb6QEdzs8+l3Rez6HywmPFxu/fhivAg==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {
@@ -18955,9 +18955,9 @@
       "version": "4.2.2"
     },
     "@yalesites-org/component-library-twig": {
-      "version": "1.15.2",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.15.2/defa43f7e4b9543a1c26dd6135fcb002d48f853e",
-      "integrity": "sha512-lcOb4ZMpJeikOrhXj+pEtxPyV3YpdWZfIE7l5JKPrk7x2NesS1C3gdPfdu9WSCGKtUlwqX5CWNcRvf7lB9N08w==",
+      "version": "1.17.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.17.0/3abaed9df8c6eda7d6fd209d6c6094f0b5757e4f",
+      "integrity": "sha512-4ESLqrOns0dyjy8uZAVNH71kWNIVhBFlq35nKhWpOFJpCv4CKj4TuYANb6QEdzs8+l3Rez6HywmPFxu/fhivAg==",
       "requires": {
         "@storybook/storybook-deployer": "^2.8.11",
         "@yalesites-org/tokens": "^1.17.4",

--- a/templates/field/field--field-media-oembed-video.html.twig
+++ b/templates/field/field--field-media-oembed-video.html.twig
@@ -1,0 +1,5 @@
+{% for item in items %}
+  {% include '@atoms/video-embed/yds-video-embed.twig' with {
+    video_embed__content: item.content,
+  } %}
+{% endfor %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -1,4 +1,5 @@
 {{ elements.alert_block }}
+
 {% embed "@organisms/site-header/yds-site-header.twig" with {
   site_name: site_name,
   site_header__border_thickness: '8',
@@ -6,9 +7,8 @@
   site_header__nav_position: getThemeSetting('nav_position'),
 } %}
   {% block site_header__utility_nav %}
-    {% embed "@organisms/menu/utility-nav/yds-utility-nav.twig" with {
-      utility_nav__search,
-    } %}
+    {# utility_nav__search is passed to this component from ys_core.module #}
+    {% embed "@organisms/menu/utility-nav/yds-utility-nav.twig" %}
       {% block utility_nav__menu %}
         {{ elements.utility_navigation }}
       {% endblock %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -6,7 +6,9 @@
   site_header__nav_position: getThemeSetting('nav_position'),
 } %}
   {% block site_header__utility_nav %}
-    {% embed "@organisms/menu/utility-nav/yds-utility-nav.twig" %}
+    {% embed "@organisms/menu/utility-nav/yds-utility-nav.twig" with {
+      utility_nav__search,
+    } %}
       {% block utility_nav__menu %}
         {{ elements.utility_navigation }}
       {% endblock %}

--- a/templates/paragraphs/paragraph--video.html.twig
+++ b/templates/paragraphs/paragraph--video.html.twig
@@ -1,0 +1,12 @@
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% embed "@molecules/video/yds-video.twig" with {
+    video__heading: content.field_heading,
+    video__text: content.field_text,
+  } %}
+    {% block video__video %}
+      {{ content.field_video }}
+    {% endblock %}
+  {% endembed %}
+</div>


### PR DESCRIPTION
## [YALB-702: Search: Hide search form](https://yaleits.atlassian.net/browse/YALB-702)

### Description of work
- Adds the ability to show or hide the search box in the utility navigation area
- Note: This requires [PR-120 from yalesites-project](https://github.com/yalesites-org/yalesites-project/pull/120) and [PR-149 from component-library-twig](https://github.com/yalesites-org/component-library-twig/pull/149) to work

### Functional testing steps:
- [x] Import config ```drush cim```
- [x] Visit any page and note the utility navigation area
- [x] Visit the settings form at ```admin/yalesites/settings```, toggle the enable search form and save
- [x] Visit any page and note that the search form can be enabled and disabled