### PR TITLE
YALB-709: Image Grid Wiring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1234,9 +1234,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.17.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.17.0/3abaed9df8c6eda7d6fd209d6c6094f0b5757e4f",
-      "integrity": "sha512-4ESLqrOns0dyjy8uZAVNH71kWNIVhBFlq35nKhWpOFJpCv4CKj4TuYANb6QEdzs8+l3Rez6HywmPFxu/fhivAg==",
+      "version": "1.18.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.18.0/eedeccea1360220f23c143c73914e8a396f53436",
+      "integrity": "sha512-ZGWc2c5L/RFfbBNsiL82JSGHFkDlmej5+UvRYyNP7oAzSOkSP06Pd+0kX8bQeADcF/Phdjm30l4qfcTUWGDP4Q==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {
@@ -18955,9 +18955,9 @@
       "version": "4.2.2"
     },
     "@yalesites-org/component-library-twig": {
-      "version": "1.17.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.17.0/3abaed9df8c6eda7d6fd209d6c6094f0b5757e4f",
-      "integrity": "sha512-4ESLqrOns0dyjy8uZAVNH71kWNIVhBFlq35nKhWpOFJpCv4CKj4TuYANb6QEdzs8+l3Rez6HywmPFxu/fhivAg==",
+      "version": "1.18.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.18.0/eedeccea1360220f23c143c73914e8a396f53436",
+      "integrity": "sha512-ZGWc2c5L/RFfbBNsiL82JSGHFkDlmej5+UvRYyNP7oAzSOkSP06Pd+0kX8bQeADcF/Phdjm30l4qfcTUWGDP4Q==",
       "requires": {
         "@storybook/storybook-deployer": "^2.8.11",
         "@yalesites-org/tokens": "^1.17.4",

--- a/templates/field/field--field-author.html.twig
+++ b/templates/field/field--field-author.html.twig
@@ -1,3 +1,3 @@
 {% for item in items %}
-  <span>{{ item.content }}</span>
+  <span>By {{ item.content }}</span>
 {% endfor %}

--- a/templates/field/field--paragraph--field-media-grid-items--media-grid.html.twig
+++ b/templates/field/field--paragraph--field-media-grid-items--media-grid.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/templates/node/node--news--full.html.twig
+++ b/templates/node/node--news--full.html.twig
@@ -1,10 +1,6 @@
-{% if content.field_author|render %}
-  {% set author = 'By ' ~ content.field_author|render %}
-{% endif %}
-
 {% include "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
-  page_title__meta: author ~ date,
+  page_title__meta: content.field_author|render ~ date,
 } %}
 
 {{ content|without('field_author') }}

--- a/templates/paragraphs/paragraph--media-grid.html.twig
+++ b/templates/paragraphs/paragraph--media-grid.html.twig
@@ -1,5 +1,3 @@
-{{ attach_library('atomic/image-grid') }}
-
 <div{{ attributes }}>
   {{ title_prefix }}
   {{ title_suffix }}
@@ -11,4 +9,3 @@
     {% endblock %}
   {% endembed %}
 </div>
-{{ kint(content) }}

--- a/templates/paragraphs/paragraph--media-grid.html.twig
+++ b/templates/paragraphs/paragraph--media-grid.html.twig
@@ -1,0 +1,14 @@
+{{ attach_library('atomic/image-grid') }}
+
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% embed "@organisms/galleries/media-grid/yds-media-grid.twig" with {
+    media_grid__heading: content.field_heading,
+  } %}
+    {% block media_grid__items %}
+      {{ content.field_media_grid_items }}
+    {% endblock %}
+  {% endembed %}
+</div>
+{{ kint(content) }}


### PR DESCRIPTION
## [YALB-709: Image Grid Wiring](https://yaleits.atlassian.net/browse/YALB-709)

### Description of work
- Wires the Image Grid component to Drupal.
- Fixes spacing between the word "By" and the author name on News nodes.

### Functional testing steps:
- [x] Navigate to site
- [x] Go to content/add content/page and click on content and choose Image Grid.
- [x] Click add media and select a picture to insert and save.
- [x] Click "add media grid items" to add a few more pictures and click save. Plublish/save.
- [x] Verify that the Image Grid is displaying on pages/News/Event nodes.
