### PR TITLE
YALB-784 and YALB-786: Drupal "Primary links" a11y fixes

### DIFF
--- a/templates/navigation/menu-local-tasks.html.twig
+++ b/templates/navigation/menu-local-tasks.html.twig
@@ -13,7 +13,9 @@
 #}
 {% if primary %}
   <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
-  {% embed "@molecules/tabs/yds-tabs.twig" %}
+  {% embed "@molecules/tabs/yds-tabs.twig" with {
+    tabs__component: 'false',
+  } %}
     {% block tab__label %}
       {{ primary }}
     {% endblock %}

--- a/templates/navigation/menu-local-tasks.html.twig
+++ b/templates/navigation/menu-local-tasks.html.twig
@@ -12,14 +12,15 @@
  */
 #}
 {% if primary %}
-  <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
-  {% embed "@molecules/tabs/yds-tabs.twig" with {
-    tabs__component: 'false',
-  } %}
-    {% block tab__label %}
-      {{ primary }}
-    {% endblock %}
-  {% endembed %}
+  <nav aria-label="{{ 'Primary tabs'|t }}">
+    {% embed "@molecules/tabs/yds-tabs.twig" with {
+      tabs__component: 'false',
+    } %}
+      {% block tab__label %}
+        {{ primary }}
+      {% endblock %}
+    {% endembed %}
+  </nav>
 {% endif %}
 {% if secondary %}
   <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>


### PR DESCRIPTION
## [YALB-784: Remove aria attribute](https://yaleits.atlassian.net/browse/YALB-784)
## [YALB-786: Add nav region to page links](https://yaleits.atlassian.net/browse/YALB-786)

**Bug ticket descriptions**
> The primary tabs (“View”, “Edit”, “Delete”, etc.) `<ul>` wrapper has a semantically incorrect ARIA role  (role="tablist"). This role should be removed.

> Wrap the page tools links (“View”, “Edit”, “Delete”, etc.) in a <nav> tag with an aria-label that describes the purpose of these links, (such as <nav aria-label="page tools">)

### Description of work
- Sets the tabs__component variable to false to prevent the `role="tabslist"` markup from being written
- Wraps the "primary" (drupal) links with a nav and aria-label per the ticket

### Functional testing steps: (everything should be run from the project root)
- [x] `lando start`
- [x] `npm run local:review-with-atomic-and-cl-branch`
	- [x] provide the branch `YALB-784-tabs-aria` for both Atomic and the component library, when asked
- [x] Create a page `/node/add/page` (You can just give it a title, with no content). Publish, and save it.
- [x] Verify the "View", "Edit", "Delete", etc. tabs `<ul>` does NOT have the `role="tablist"` markup
- [x] Verify they DO have a wrapping `<nav>` element with an appropriate aria-label
