### PR TITLE
YALB-877: Wrapped image styles

### DIFF
--- a/templates/paragraphs/paragraph--wrapped-image.html.twig
+++ b/templates/paragraphs/paragraph--wrapped-image.html.twig
@@ -1,4 +1,6 @@
 {% embed "@molecules/wrapped-image/yds-wrapped-image.twig" with {
+  wrapped_image__style: content.field_style_variation.0['#markup'],
+  wrapped_image__alignment: content.field_style_position.0['#markup'],
   wrapped_image__content: content.field_text.0,
   wrapped_image__caption: content.field_caption.0['#text'],
 } %}


### PR DESCRIPTION
## [YALB-877: Wrapped image styles](https://yaleits.atlassian.net/browse/YALB-877)

### Description of work
- Passes the variation controls for the "wrapped image" paragraph.

### Functional testing steps:
- This work should be tested in the platform PR
https://github.com/yalesites-org/yalesites-project/pull/189