### PR TITLE
YALB-913: Bug: Search results page

### DIFF
--- a/templates/form/ys-search-form.html.twig
+++ b/templates/form/ys-search-form.html.twig
@@ -1,6 +1,6 @@
-<form action="/search" method="get" class="search-form--page" id="page-search-form" accept-charset="UTF-8">
+<form action="/search" method="get" class="search-form--page form--inline" id="page-search-form" accept-charset="UTF-8">
   <div class="form-item form-item-keywords">
-    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value="" size="30" maxlength="128" class="form-text">
+    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value="" size="30" maxlength="128" class="form-text form-item__textfield">
   </div>
   <div class="form-actions form-wrapper" id="edit-actions--page-search-form">
     {% include '@atoms/controls/cta/yds-cta.twig' with {


### PR DESCRIPTION
## [YALB-913: Bug: Search results page](https://yaleits.atlassian.net/browse/YALB-913)

### Description of work
- Added padding underneath search page form
- Increases height of text input within search page form
- Before: 
![image](https://user-images.githubusercontent.com/119528620/211667143-81b42178-682e-4f1f-9e6d-8b5b8181755f.png)
- After:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/119528620/211667248-6588825b-97c2-471c-8015-a8e1436913b3.png">
- Companion PR in component-twig-library: https://github.com/yalesites-org/component-library-twig/pull/185


### Functional testing steps:
- [x] Run `npm run local:review-with-atomic-and-cl-branch` and enter `YALB-913-search-results-page-style-fix` for both branches
- [x] Make sure your local development environment has content to find via search
- [x] Search for content.
- [x] Verify that the input is the correct height and there is the correct margin between the form and the results
