### PR TITLE
YALB-980: Alignment: Global widths - template updates - wire component library variables

### DIFF
--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -2,6 +2,7 @@
 
 {% embed "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
+  page_title__width: 'highlight',
 } %}
   {% block page_title__meta %}
     {% set event_meta__all_day = content.field_event_date.0.end['#text'].time['#markup'] == 'All day' ? true : false %}

--- a/templates/node/node--news--full.html.twig
+++ b/templates/node/node--news--full.html.twig
@@ -3,6 +3,7 @@
 {% include "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
   page_title__meta: content.field_author|render ~ date,
+  page_title__width: 'highlight',
 } %}
 
 {{ content|without('field_author') }}

--- a/templates/paragraphs/paragraph--custom-cards.html.twig
+++ b/templates/paragraphs/paragraph--custom-cards.html.twig
@@ -1,5 +1,6 @@
 {% embed "@organisms/custom-card-collection/yds-custom-card-collection.twig" with {
   custom_card_collection__heading: content.field_heading.0['#text'],
+  custom_card_collection__width: 'max',
 } %}
   {% block custom_card_collection__cards %}
     {{ content.field_cards }}

--- a/templates/paragraphs/paragraph--gallery.html.twig
+++ b/templates/paragraphs/paragraph--gallery.html.twig
@@ -3,6 +3,7 @@
 {% embed "@organisms/galleries/media-grid/yds-media-grid.twig" with {
   media_grid__heading: content.field_heading,
   media_grid__variation: 'interactive',
+  media_grid__width: 'max',
 } %}
   {% block media_grid__items %}
     {% include "@atomic/paragraphs/_gallery-item.twig" with {

--- a/templates/paragraphs/paragraph--media-grid.html.twig
+++ b/templates/paragraphs/paragraph--media-grid.html.twig
@@ -1,5 +1,6 @@
 {% embed "@organisms/galleries/media-grid/yds-media-grid.twig" with {
   media_grid__heading: content.field_heading,
+  media_grid__width: 'max',
 } %}
   {% block media_grid__items %}
     {{ content.field_media_grid_items }}

--- a/templates/paragraphs/paragraph--text.html.twig
+++ b/templates/paragraphs/paragraph--text.html.twig
@@ -1,7 +1,3 @@
-{% if content.field_text_left_align.0['#markup'] == 'True' %}
-  {% set text_field__width = 'max' %}
-{% endif %}
-
 {% include "@molecules/text/yds-text-field.twig" with {
   text_field__content: content.field_text,
   text_field__width: text_field__width,

--- a/templates/paragraphs/paragraph--text.html.twig
+++ b/templates/paragraphs/paragraph--text.html.twig
@@ -1,4 +1,4 @@
-{% if content.field_text_left_align %}
+{% if content.field_text_left_align.0['#markup'] == 'True' %}
   {% set text_field__width = 'max' %}
 {% endif %}
 

--- a/templates/paragraphs/paragraph--text.html.twig
+++ b/templates/paragraphs/paragraph--text.html.twig
@@ -1,3 +1,8 @@
+{% if content.field_text_left_align %}
+  {% set text_field__width = 'max' %}
+{% endif %}
+
 {% include "@molecules/text/yds-text-field.twig" with {
   text_field__content: content.field_text,
+  text_field__width: text_field__width,
 } %}

--- a/templates/views/views-view--event-cards.html.twig
+++ b/templates/views/views-view--event-cards.html.twig
@@ -15,6 +15,7 @@
   {% embed "@organisms/card-collection/yds-card-collection.twig" with {
     card_collection__heading: view.args.0,
     card_collection__featured: 'false',
+    card_collection__width: 'max',
   } %}
     {% block card_collection__cards %}
       {{ rows }}

--- a/templates/views/views-view--news-cards.html.twig
+++ b/templates/views/views-view--news-cards.html.twig
@@ -15,6 +15,7 @@
   {% embed "@organisms/card-collection/yds-card-collection.twig" with {
     card_collection__heading: view.args.0,
     card_collection__featured: 'false',
+    card_collection__width: 'max',
   } %}
     {% block card_collection__cards %}
       {{ rows }}


### PR DESCRIPTION
## [YALB-980: Alignment: Global widths](https://yaleits.atlassian.net/browse/YALB-980)

### Description of work
- passing `width` values in to components to change their widths in Drupal
- setting `page_title__width: 'highlight'` in both the Event and News full templates to reduce the width of page title
- set `media gallery`, `news-cards` and `event-cards` Drupal template includes to `'max'` width

### Functional Review Steps
- [ ] Test here https://github.com/yalesites-org/yalesites-project/pull/208

