### PR TITLE
YALB-944: Define template for views basic

### DIFF
--- a/templates/views/views-view--views-basic-scaffold.html.twig
+++ b/templates/views/views-view--views-basic-scaffold.html.twig
@@ -1,0 +1,41 @@
+{# @todo refactor how views basic is rendered. #}
+{% set type = view.rowPlugin.options['view_mode'] == 'list_item' ? 'list' : 'grid' %}
+
+{{ title_prefix }}
+{{ title }}
+{{ title_suffix }}
+
+{% if header %}
+  <header>
+    {{ header }}
+  </header>
+{% endif %}
+
+{{ exposed }}
+{{ attachment_before }}
+
+{% if rows -%}
+  {% embed "@organisms/card-collection/yds-card-collection.twig" with {
+    card_collection__featured: 'false',
+    card_collection__width: 'max',
+    card_collection__type: type,
+  } %}
+    {% block card_collection__cards %}
+      {{ rows }}
+    {% endblock %}
+  {% endembed %}
+{% elseif empty -%}
+  {{ empty }}
+{% endif %}
+{{ pager }}
+
+{{ attachment_after }}
+{{ more }}
+
+{% if footer %}
+  <footer>
+    {{ footer }}
+  </footer>
+{% endif %}
+
+{{ feed_icons }}


### PR DESCRIPTION
## [YALB-944: Template for views basic](https://yaleits.atlassian.net/browse/YALB-944)

### Description of work
- Adds a template for the views basic scaffold view.
- This is be refactored in future work but unblocks us for testing the views basic system.

### Testing
- [ ] Add a view to a content page and verify that the view displays as a card collection.
- [ ] Toggle the list and grid modes to verify it still works.
