### PR TITLE
YALB-1018: Bug: Search results shows placeholder

### DIFF
--- a/templates/views/views-view--search.html.twig
+++ b/templates/views/views-view--search.html.twig
@@ -6,7 +6,7 @@
 {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
   component_width: 'max',
 } %}
-  {% block compontent_wrapper__component %}
+  {% block component_wrapper_inner %}
     {{ title_prefix }}
       {{ title }}
       {{ title_suffix }}


### PR DESCRIPTION
## [YALB-1018: Bug: Search results shows placeholder](https://yaleits.atlassian.net/browse/YALB-1018)

### Description of work
- Fixes bug where search results did not show and instead only showed "placeholder" text.

### Functional testing steps:
- [x] Search for something using the top utility nav search box
- [x] Verify that search results are returned instead of placeholder text