### PR TITLE
YALB-1051): Fix Accordion spacing

### DIFF
--- a/templates/paragraphs/paragraph--text.html.twig
+++ b/templates/paragraphs/paragraph--text.html.twig
@@ -8,8 +8,14 @@
   {% set text_field__alignment = "left" %}
 {% endif %}
 
+{# To avoid having a margin-bottom in Accordion's items #}
+{% if parentNode == 'accordion_item' %}
+  {% set text_field__base_class = 'inner-text-field' %}
+{% endif %}
+
 {% include "@molecules/text/yds-text-field.twig" with {
   text_field__content: content.field_text,
   text_field__width: text_field__width,
   text_field__alignment: text_field__alignment,
+  text_field__base_class: text_field__base_class,
 } %}


### PR DESCRIPTION
## [YALB-1051: Feedback: Accordion spacing](https://yaleits.atlassian.net/browse/YALB-1051)

### Description of work
- Set a `text_field__base_class` different to `text-field` in `paragraph--text.html.twig` to send it to the `yds-text-field.twig` file, when the paragraph parent node is `accordion-item` to avoid having an extra margin-bottom in this scenario.

### Functional Review Steps
- [ ] To review this, you has to review it with this [Pull Request](https://github.com/yalesites-org/component-library-twig/pull/215) in your local. In the root of the project `yalesites-project` run `npm run local:review-with-atomic-and-cl-branch yalb-1051--fix-acorrdion-spacing yalb-1051--fix-acorrdion-spacing`
- [ ] Add an `Accordion` in a Standard Page and confirm the space between the expanded text block and the divider line looks as expected in the [design](https://deploy-preview-213--dev-component-library-twig.netlify.app/iframe.html?id=page-examples-standard-pages--with-banner-left-align&viewMode=story)
