### PR TITLE
fix(yalb-1104): alignment fix - update featured variable from false to true

### DIFF
--- a/templates/views/views-view--event-list.html.twig
+++ b/templates/views/views-view--event-list.html.twig
@@ -14,7 +14,7 @@
 {% if rows -%}
   {% embed "@organisms/card-collection/yds-card-collection.twig" with {
     card_collection__heading: view.args.0,
-    card_collection__featured: 'false',
+    card_collection__featured: 'true',
     card_collection__type: 'list',
   } %}
     {% block card_collection__cards %}

--- a/templates/views/views-view--news-list.html.twig
+++ b/templates/views/views-view--news-list.html.twig
@@ -14,7 +14,7 @@
 {% if rows -%}
   {% embed "@organisms/card-collection/yds-card-collection.twig" with {
     card_collection__heading: view.args.0,
-    card_collection__featured: 'false',
+    card_collection__featured: 'true',
     card_collection__type: 'list',
   } %}
     {% block card_collection__cards %}


### PR DESCRIPTION
### The issue:
This came out of multidev review from the alignment work, here https://dev-yalesites-sebastianna.pantheonsite.io/news-events

![Screenshot-20230413151258-2205x1291](https://user-images.githubusercontent.com/366413/231872617-0b26608a-0586-4561-9c9e-423112d3f75e.png)

The views display is pulling in the non-featured, smaller-image, version of the card list display. 

### This branch: 
With these branch fixes,, these displays will change from what you see above, to this, below: 
![Screenshot-20230413151309-2287x1409](https://user-images.githubusercontent.com/366413/231872776-f9a6baf7-6731-4cc0-8d31-b66fa6e4e89e.png)


---
### Description of work
- Updates news and event list displays to use the `featured` display instead of the smaller-image version. 

### Functional testing steps:
- [ ] Review code changes
