### PR TITLE
YALB-1141 - Apply alignment rules to layout builder

### DIFF
--- a/templates/block/layout-builder/block--inline-block--event-list.html.twig
+++ b/templates/block/layout-builder/block--inline-block--event-list.html.twig
@@ -2,6 +2,14 @@
 
 {% block content %}
 
+  {% set view__attibutes = {
+    'data-component-width': 'content',
+    'data-embedded-components': 'true',
+    'data-collection-featured': 'true',
+    'data-collection-type': 'list',
+    class: bem(view__base_class, view__modifiers),
+  } %}
+  
   {{ drupal_view('event_list', 'full', content.field_heading.0['#text']) }}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--gallery.html.twig
+++ b/templates/block/layout-builder/block--inline-block--gallery.html.twig
@@ -4,8 +4,6 @@
 
   {{ attach_library('atomic/gallery') }}
 
-  {% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
-
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set media_grid__width = "content" %}
   {% else %}

--- a/templates/block/layout-builder/block--inline-block--image.html.twig
+++ b/templates/block/layout-builder/block--inline-block--image.html.twig
@@ -1,9 +1,6 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
-
-  {% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
-
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set content_image__width = "content" %}
     {% set content_image__alignment = "center" %}

--- a/templates/block/layout-builder/block--inline-block--media-grid.html.twig
+++ b/templates/block/layout-builder/block--inline-block--media-grid.html.twig
@@ -1,9 +1,6 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
-
-  {% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
-
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set media_grid__width = "content" %}
   {% else %}

--- a/templates/block/layout-builder/block--inline-block--post-list.html.twig
+++ b/templates/block/layout-builder/block--inline-block--post-list.html.twig
@@ -2,6 +2,13 @@
 
 {% block content %}
 
+  {% set view__attibutes = {
+    'data-component-width': 'content',
+    'data-embedded-components': 'true',
+    'data-collection-featured': 'true',
+    'data-collection-type': 'list',
+    class: bem(view__base_class, view__modifiers),
+  } %}
   {{ drupal_view('post_list', 'full', content.field_heading.0['#text']) }}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--pull-quote.html.twig
+++ b/templates/block/layout-builder/block--inline-block--pull-quote.html.twig
@@ -2,6 +2,16 @@
 
 {% block content %}
 
+  {% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
+
+    {% if parentNode == 'post' or parentNode == 'event' %}
+      {% set pull_quote__width = "content" %}
+      {% set pull_quote__alignment = "center" %}
+    {% else %}
+      {% set pull_quote__width = "site" %}
+      {% set pull_quote__alignment = "left" %}
+  {% endif %}
+
   {% include "@molecules/pull-quote/yds-pull-quote.twig" with {
     pull_quote__quote: content.field_text,
     pull_quote__attribution: content.field_caption.0,

--- a/templates/block/layout-builder/block--inline-block--pull-quote.html.twig
+++ b/templates/block/layout-builder/block--inline-block--pull-quote.html.twig
@@ -1,9 +1,6 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
-
-  {% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
-
     {% if parentNode == 'post' or parentNode == 'event' %}
       {% set pull_quote__width = "content" %}
       {% set pull_quote__alignment = "center" %}

--- a/templates/block/layout-builder/block--inline-block--tabs.html.twig
+++ b/templates/block/layout-builder/block--inline-block--tabs.html.twig
@@ -2,6 +2,14 @@
 
 {% block content %}
 
+  {% if parentNode == 'post' or parentNode == 'event' %}
+    {% set component_wrapper__width = "content" %}
+    {% set component_wrapper__alignment = "center" %}
+  {% else %}
+    {% set component_wrapper__width = "site" %}
+    {% set component_wrapper__alignment = "left" %}
+  {% endif %}
+
   {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
     component_wrapper__width: component_wrapper__width|default('site'),
     component_wrapper__alignment: component_wrapper__alignment|default('left'),

--- a/templates/block/layout-builder/block--inline-block--text.html.twig
+++ b/templates/block/layout-builder/block--inline-block--text.html.twig
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-{% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
-
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set text_field__width = "content" %}
     {% set text_field__alignment = "center" %}

--- a/templates/block/layout-builder/block--inline-block--text.html.twig
+++ b/templates/block/layout-builder/block--inline-block--text.html.twig
@@ -2,6 +2,16 @@
 
 {% block content %}
 
+{% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
+
+  {% if parentNode == 'post' or parentNode == 'event' %}
+    {% set text_field__width = "content" %}
+    {% set text_field__alignment = "center" %}
+  {% else %}
+    {% set text_field__width = "site" %}
+    {% set text_field__alignment = "left" %}
+  {% endif %}
+
   {% embed "@molecules/text/yds-text-field.twig" with {
     text_field__content: content.field_text,
     text_field__width: text_field__width,

--- a/templates/block/layout-builder/block--inline-block--video.html.twig
+++ b/templates/block/layout-builder/block--inline-block--video.html.twig
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-  {% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
-
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set video__width = "content" %}
     {% set video__alignment = "center" %}

--- a/templates/block/layout-builder/block--inline-block--view.html.twig
+++ b/templates/block/layout-builder/block--inline-block--view.html.twig
@@ -4,11 +4,19 @@
 
   {% set view__base_class = 'ys-view' %}
 
-  {% set view__attibutes = {
-    'data-component-width': 'site',
-    'data-embedded-components': 'true',
-    class: bem(view__base_class, view__modifiers),
-  } %}
+  {% if parentNode == 'post' or parentNode == 'event' %}
+    {% set view__attibutes = {
+      'data-component-width': 'content',
+      'data-embedded-components': 'true',
+      class: bem(view__base_class, view__modifiers),
+    } %}
+    {% else %}
+      {% set view__attibutes = {
+        'data-component-width': 'site',
+        'data-embedded-components': 'true',
+        class: bem(view__base_class, view__modifiers),
+      } %}
+  {% endif %}
 
   <div {{ add_attributes(view__attibutes) }}>
     {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {

--- a/templates/block/layout-builder/block--inline-block--view.html.twig
+++ b/templates/block/layout-builder/block--inline-block--view.html.twig
@@ -6,20 +6,20 @@
 
   {% set view__attibutes = {
     'data-component-width': 'site',
+    'data-embedded-components': 'true',
     class: bem(view__base_class, view__modifiers),
   } %}
 
-  <div {{ bem('inner', [], view__base_class) }}>
-    {% if content.field_heading  %}
-      {% include "@atoms/typography/headings/yds-heading.twig" with {
-        heading__level: '2',
-        heading__blockname: view__base_class,
-        heading: content.field_heading ,
-      } %}
-    {% endif %}
-    {% if content.field_view_params  %}
-      {{ content.field_view_params }}
-    {% endif %}
+  <div {{ add_attributes(view__attibutes) }}>
+    {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
+      component_wrapper__width: component_wrapper__width|default('site'),
+      component_wrapper__label: content.field_heading,
+      }%}
+      {% if content.field_view_params  %}
+        {% block component_wrapper_inner %}
+          {{ content.field_view_params }}
+        {% endblock %}
+      {% endif %}
+    {% endembed %}
   </div>
-
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--wrapped-image.html.twig
+++ b/templates/block/layout-builder/block--inline-block--wrapped-image.html.twig
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-  {% set parentNode = paragraph.parentEntity.type.value.0['target_id'] %}
-
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set wrapped_image__width = "content" %}
   {% else %}


### PR DESCRIPTION
## [YALB-1141 - Apply alignment rules to layout builder](https://yaleits.atlassian.net/browse/YALB-1141)

### Description of work
- fix(yalb-1141): fix alignment - conditionals in block templates
- adds in conditional width/alignment changes based on parentNode

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/247
- [ ] Note that I restructured the views template to include a properly aligned component title along with using the component-wrapper. It also applies `'data-embedded-components': 'true',` to remove `padding` from the reference card grid. 
