### PR TITLE
YALB-395: Metadata: Fallback for teaser images (BE)

### DIFF
--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -24,6 +24,12 @@
   reference_card__image: 'true',
 } %}
   {% block reference_card__image %}
-    {{ content.field_teaser_media }}
+
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% else %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
+    {% endif %}
+
   {% endblock %}
 {% endembed %}

--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -27,7 +27,7 @@
 
     {% if content.field_teaser_media[0] %}
       {{ content.field_teaser_media }}
-    {% else %}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
       {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
     {% endif %}
 

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -24,6 +24,12 @@
   reference_card__image: 'true',
 } %}
   {% block reference_card__image %}
-    {{ content.field_teaser_media }}
+
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% else %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
+    {% endif %}
+
   {% endblock %}
 {% endembed %}

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -27,7 +27,7 @@
 
     {% if content.field_teaser_media[0] %}
       {{ content.field_teaser_media }}
-    {% else %}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
       {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
     {% endif %}
 

--- a/templates/node/node--post--card.html.twig
+++ b/templates/node/node--post--card.html.twig
@@ -19,7 +19,7 @@
 
     {% if content.field_teaser_media[0] %}
       {{ content.field_teaser_media }}
-    {% else %}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
       {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
     {% endif %}
 

--- a/templates/node/node--post--card.html.twig
+++ b/templates/node/node--post--card.html.twig
@@ -16,6 +16,12 @@
   reference_card__snippet: content.field_teaser_text,
 } %}
   {% block reference_card__image %}
-    {{ content.field_teaser_media }}
+
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% else %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
+    {% endif %}
+
   {% endblock %}
 {% endembed %}

--- a/templates/node/node--post--list-item.html.twig
+++ b/templates/node/node--post--list-item.html.twig
@@ -19,7 +19,7 @@
     {% if content.field_teaser_media[0] %}
       {{ content.field_teaser_media }}
     {% else %}
-      {{ drupal_entity('media', getCoreSetting('image_defaults.teaser'), 'card_list_3_2') }}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
     {% endif %}
   {% endblock %}
 {% endembed %}

--- a/templates/node/node--post--list-item.html.twig
+++ b/templates/node/node--post--list-item.html.twig
@@ -16,6 +16,10 @@
   reference_card__snippet: content.field_teaser_text,
 } %}
   {% block reference_card__image %}
-    {{ content.field_teaser_media }}
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% else %}
+      {{ drupal_entity('media', getCoreSetting('image_defaults.teaser'), 'card_list_3_2') }}
+    {% endif %}
   {% endblock %}
 {% endembed %}

--- a/templates/node/node--post--list-item.html.twig
+++ b/templates/node/node--post--list-item.html.twig
@@ -16,10 +16,12 @@
   reference_card__snippet: content.field_teaser_text,
 } %}
   {% block reference_card__image %}
+
     {% if content.field_teaser_media[0] %}
       {{ content.field_teaser_media }}
-    {% else %}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
       {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
     {% endif %}
+
   {% endblock %}
 {% endembed %}


### PR DESCRIPTION
## [YALB-395: Metadata: Fallback for teaser images (BE)](https://yaleits.atlassian.net/browse/YALB-395)

### Description of work
- Adds logic in the twig templates for post and event cards and lists to use the fallback teaser image if a teaser image is not set on the post or event node
- Requires [YaleSites Project PR-263](https://github.com/yalesites-org/yalesites-project/pull/263)
- [Testing multidev here](https://pr-263-yalesites-platform.pantheonsite.io/)

### Functional testing steps:
- [ ] [Testing steps here](https://github.com/yalesites-org/yalesites-project/pull/263)