### PR TITLE
YALB-1185  - Atomic Drupal 10 Compatibility

### DIFF
--- a/atomic.info.yml
+++ b/atomic.info.yml
@@ -3,7 +3,7 @@ type: theme
 description: YaleSites starter theme using Storybook and component-driven development
 base theme: stable9
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 
 libraries:
   - atomic/global

--- a/atomic.info.yml
+++ b/atomic.info.yml
@@ -2,7 +2,6 @@ name: atomic
 type: theme
 description: YaleSites starter theme using Storybook and component-driven development
 base theme: stable9
-core: 8.x
 core_version_requirement: ^9 || ^10
 
 libraries:

--- a/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
+++ b/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
@@ -8,21 +8,24 @@
     grand_hero__link__content: content.field_link.0['#title'],
     grand_hero__link__url: content.field_link.0['#url_title'],
     grand_hero__content__background: content.field_style_color.0['#markup'],
-    grand_hero__overlay_variation: content.field_style_position.0['#markup'],
-    grand_hero__size: content.field_style_variation.0['#markup'],
+    grand_hero__overlay_variation: content.field_style_variation.0['#markup'],
+    grand_hero__size: content.field_style_position.0['#markup'],
     grand_hero__width: 'site',
   } %}
 
+  {% block grand_hero__video %}
     {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is not empty %}
       {% set grand_hero__video = true %}
-        {% block grand_hero__video %}
-          {{ content.field_media }}
-        {% endblock %}
-      {% else %}
-      {% block grand_hero__image %}
-        {{ content.field_media }}
-      {% endblock %}
+      {{ content.field_media }}
     {% endif %}
+  {% endblock %}
+
+  {% block grand_hero__image %}
+    {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is empty %}
+      {{ content.field_media }}
+    {% endif %}
+  {% endblock %}
+
 
   {% endembed %}
 

--- a/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
+++ b/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
@@ -12,21 +12,17 @@
     grand_hero__size: content.field_style_position.0['#markup'],
     grand_hero__width: 'site',
   } %}
+    {% block grand_hero__video %}
+      {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is not empty %}
+        {% set grand_hero__video = true %}
+        {{ content.field_media }}
+      {% endif %}
+    {% endblock %}
 
-  {% block grand_hero__video %}
-    {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is not empty %}
-      {% set grand_hero__video = true %}
-      {{ content.field_media }}
-    {% endif %}
-  {% endblock %}
-
-  {% block grand_hero__image %}
-    {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is empty %}
-      {{ content.field_media }}
-    {% endif %}
-  {% endblock %}
-
-
+    {% block grand_hero__image %}
+      {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is empty %}
+        {{ content.field_media }}
+      {% endif %}
+    {% endblock %}
   {% endembed %}
-
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--view.html.twig
+++ b/templates/block/layout-builder/block--inline-block--view.html.twig
@@ -23,11 +23,11 @@
       component_wrapper__width: component_wrapper__width|default('site'),
       component_wrapper__label: content.field_heading,
       }%}
-      {% if content.field_view_params  %}
-        {% block component_wrapper_inner %}
+      {% block component_wrapper_inner %}
+        {% if content.field_view_params %}
           {{ content.field_view_params }}
-        {% endblock %}
-      {% endif %}
+        {% endif %}
+      {% endblock %}
     {% endembed %}
   </div>
 {% endblock %}


### PR DESCRIPTION
## [YALB-1185  - Atomic Drupal 10 Compatibility](https://yaleits.atlassian.net/browse/YALB-1185)

### Description of work
- Fixes twig syntax issue in two layout builder block templates
  -  atomic/templates/block/layout-builder/block--inline-block--view.html.twig 
  -  atomic/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
  - Fixed based on suggestion here: https://eleni.blog/2019/04/14/upgrading-to-twig-2/
- Adds Drupal 10 compatibility to `atomic.info.yml` file by removing the `core` line and changing `core_version_requirement` to `core_version_requirement: ^9 || ^10`
- While I was in the grand hero template, I swapped the field values in the grand hero, which relates to https://yaleits.atlassian.net/browse/YALB-1146 but doesn't entirely fix that issue. 


### Functional testing steps:
- [x] Test in YaleSites project (https://github.com/yalesites-org/yalesites-project) branch `YALB-1186-drupal10` to get D10 updates to test Atomic
- [x] Checkout this PR branch of Atomic `yalb-1185`
- [x] Run `npm run build-with-assets` in YaleSites-project
- [x] Login and verify compatibility by navigating to https://yalesites-platform.lndo.site/admin/reports/upgrade-status
  - note compatibility :  
![Screenshot-20230510171615-2254x57](https://github.com/yalesites-org/atomic/assets/366413/5e90fa11-61d0-4661-9a05-c5ddc1bcdaf0)
- [x] Edit a page and add a `grand hero banner` to the top/banner section, select a video like this one: 
https://github.com/yalesites-org/atomic/assets/366413/f17314fd-1492-486e-bc77-61d51ddbe2a7
- [x] View the page and verify the video stills works (see notes section below for an issue about the play/pause button)
![Screenshot-20230510173745-2527x1241](https://github.com/yalesites-org/atomic/assets/366413/69f7a819-2aaf-4780-bd1d-fed22eccdf00)


- [x] Edit the page and change the grand hero to use an image instead
- [x] Verify the grand hero displays the image
![Screenshot-20230510172755-2528x1311](https://github.com/yalesites-org/atomic/assets/366413/6512d22e-a820-4a17-891b-f2a28cb1c3bd)

- [ ] Next, add a `view`
- [ ] Save and verify the view still displays as it should
![Screenshot-20230510172736-1179x919](https://github.com/yalesites-org/atomic/assets/366413/70f69ae6-1786-4755-936b-d94d77a3eedf)



### Notes: 
- While testing the grand hero video component, I noticed an issue with the play/pause `button` theme. I have added this issue to the relevant ticket here: https://yaleits.atlassian.net/browse/YALB-1146 | comment here: https://yaleits.atlassian.net/browse/YALB-1146?focusedCommentId=106915