### PR TITLE
YALB-1163 - Create Button Link component

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -45,3 +45,10 @@ gallery:
 background-video:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/videos/video-background/yds-video-background.js: {}
+
+fontawesome: 
+  css:
+    theme: 
+      node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/fontawesome.css: {}
+      node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/regular.css: {}
+      node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/solid.css: {}

--- a/templates/block/layout-builder/block--inline-block--button-link.html.twig
+++ b/templates/block/layout-builder/block--inline-block--button-link.html.twig
@@ -3,15 +3,15 @@
 {% block content %}
 
   {% if parentNode == 'post' or parentNode == 'event' %}
-    {% set component__width = "content" %}
-    {% set component__alignment = "center" %}
+    {% set component_wrapper__width = "content" %}
+    {% set component_wrapper__alignment = "center" %}
   {% else %}
-    {% set component__width = "site" %}
-    {% set component__alignment = "left" %}
+    {% set component_wrapper__width = "site" %}
+    {% set component_wrapper__alignment = "left" %}
   {% endif %}
 
   {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
-    component_width: component_width,
+    component_wrapper__width: component_width,
     component_wrapper__label: content.field_heading,
   } %}
     {% block component_wrapper_inner %}

--- a/templates/block/layout-builder/block--inline-block--button-link.html.twig
+++ b/templates/block/layout-builder/block--inline-block--button-link.html.twig
@@ -1,0 +1,27 @@
+{% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
+
+{% block content %}
+
+  {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
+    component_width: 'site',
+    component_wrapper__label: content.field_heading,
+  } %}
+    {% block component_wrapper_inner %}
+      {% include "@atoms/controls/cta/yds-cta.twig" with {
+        cta__element: 'a',
+        cta__content: content.field_button_link.0['#title'],
+        cta__href: content.field_button_link.0['#url_title'],
+        cta__component_theme: cta__component_theme|default('one'),
+      }%}
+      {% if content.field_button_link.1['#url_title'] is not empty %}
+        {% include "@atoms/controls/cta/yds-cta.twig" with {
+          cta__element: 'a',
+          cta__content: content.field_button_link.1['#title'],
+          cta__href: content.field_button_link.1['#url_title'],
+          cta__component_theme: cta__component_theme|default('one'),
+          cta__style: 'outline',
+        }%}
+      {% endif %}
+    {% endblock %}
+  {% endembed %}
+{% endblock %}

--- a/templates/block/layout-builder/block--inline-block--button-link.html.twig
+++ b/templates/block/layout-builder/block--inline-block--button-link.html.twig
@@ -2,26 +2,36 @@
 
 {% block content %}
 
+  {% if parentNode == 'post' or parentNode == 'event' %}
+    {% set component__width = "content" %}
+    {% set component__alignment = "center" %}
+  {% else %}
+    {% set component__width = "site" %}
+    {% set component__alignment = "left" %}
+  {% endif %}
+
   {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
-    component_width: 'site',
+    component_width: component_width,
     component_wrapper__label: content.field_heading,
   } %}
     {% block component_wrapper_inner %}
-      {% include "@atoms/controls/cta/yds-cta.twig" with {
-        cta__element: 'a',
-        cta__content: content.field_button_link.0['#title'],
-        cta__href: content.field_button_link.0['#url_title'],
-        cta__component_theme: cta__component_theme|default('one'),
-      }%}
-      {% if content.field_button_link.1['#url_title'] is not empty %}
+      <div class="cta-group">
         {% include "@atoms/controls/cta/yds-cta.twig" with {
           cta__element: 'a',
-          cta__content: content.field_button_link.1['#title'],
-          cta__href: content.field_button_link.1['#url_title'],
+          cta__content: content.field_button_link.0['#title'],
+          cta__href: content.field_button_link.0['#url_title'],
           cta__component_theme: cta__component_theme|default('one'),
-          cta__style: 'outline',
         }%}
-      {% endif %}
+        {% if content.field_button_link.1['#url_title'] is not empty %}
+          {% include "@atoms/controls/cta/yds-cta.twig" with {
+            cta__element: 'a',
+            cta__content: content.field_button_link.1['#title'],
+            cta__href: content.field_button_link.1['#url_title'],
+            cta__component_theme: cta__component_theme|default('one'),
+            cta__style: 'outline',
+          }%}
+        {% endif %}
+      </div>
     {% endblock %}
   {% endembed %}
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--button-link.html.twig
+++ b/templates/block/layout-builder/block--inline-block--button-link.html.twig
@@ -13,6 +13,7 @@
   {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
     component_wrapper__width: component_width,
     component_wrapper__label: content.field_heading,
+    component__modifiers: ['no-top-margin'],
   } %}
     {% block component_wrapper_inner %}
       <div class="cta-group">

--- a/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
+++ b/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
@@ -2,14 +2,16 @@
 
 {% block content %}
 
+  {{ attach_library('atomic/fontawesome') }}
+
   {% embed "@molecules/banner/grand-hero/yds-grand-hero.twig" with {
     grand_hero__heading: content.field_heading,
     grand_hero__snippet: content.field_text,
     grand_hero__link__content: content.field_link.0['#title'],
     grand_hero__link__url: content.field_link.0['#url_title'],
     grand_hero__content__background: content.field_style_color.0['#markup'],
-    grand_hero__overlay_variation: content.field_style_position.0['#markup'],
-    grand_hero__size: content.field_style_variation.0['#markup'],
+    grand_hero__overlay_variation: content.field_style_variation.0['#markup'],
+    grand_hero__size: content.field_style_position.0['#markup'],
     grand_hero__width: 'site',
   } %}
 

--- a/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
+++ b/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
@@ -10,8 +10,8 @@
     grand_hero__link__content: content.field_link.0['#title'],
     grand_hero__link__url: content.field_link.0['#url_title'],
     grand_hero__content__background: content.field_style_color.0['#markup'],
-    grand_hero__overlay_variation: content.field_style_variation.0['#markup'],
-    grand_hero__size: content.field_style_position.0['#markup'],
+    grand_hero__overlay_variation: content.field_style_position.0['#markup'],
+    grand_hero__size: content.field_style_variation.0['#markup'],
     grand_hero__width: 'site',
   } %}
 


### PR DESCRIPTION
## [YALB-1163 - Create Button Link component](https://yaleits.atlassian.net/browse/YALB-1163) | [YALB-1146 - Bug: Short grand hero banner is too short](https://yaleits.atlassian.net/browse/YALB-1146)

### Description of work
- YALB-1163 - Adds button-link template
- YALB-1146 - Adds `fontawesome` css as a library - this is a fix because it was not previously added in Drupal. Currently, this only affects the `text-link` component as it's used in the grand hero. I noticed that the text-link in the grand hero was missing its chevron and since I was here I rolled it into 1146.
- YALB-1146 - Fixes grand hero with video play/pause button
- YALB-1146 - Fixes grand hero data attributes - which is this ticket: https://yaleits.atlassian.net/browse/YALB-1146

### Functional testing steps:
- [x] Test here: https://github.com/yalesites-org/yalesites-project/pull/267
- [x] Verify code changes in this repository are solid
