### PR TITLE
YALB-1195: Events: Add to Calendar Link (BE)

### DIFF
--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -8,12 +8,12 @@
     {% set event_meta__all_day = content.field_event_date.0.end['#text'].time['#markup'] == 'All day' ? true : false %}
     {% set cal_link = calendar_link('ics', 'title', date(), date(), event_meta__all_day, 'description', 'location') %}
     {% include "@molecules/meta/event-meta/yds-event-meta.twig" with {
-      event_meta__date_start: content.field_event_date.0.start['#text'].date['#markup'],
-      event_meta__date_end: content.field_event_date.0.end['#text'].date['#markup'],
-      event_meta__format: content.field_event_format,
+      event_meta__date_start: node.field_event_date.value,
+      event_meta__date_end: node.field_event_date.end_value,
+      event_meta__format: node.field_event_format.value,
       event_meta__address: nothing_yet,
-      event_meta__cta_primary__content: content.field_event_cta.0['#title'],
-      event_meta__cta_primary__href: content.field_event_cta.0['#url_title'],
+      event_meta__cta_primary__content: node.field_event_cta.title,
+      event_meta__cta_primary__href: node.field_event_cta.uri,
       event_meta__cta_secondary__content: 'Add to Calendar',
       event_meta__cta_secondary__href: cal_link,
     } %}

--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -6,6 +6,7 @@
 } %}
   {% block page_title__meta %}
     {% set event_meta__all_day = content.field_event_date.0.end['#text'].time['#markup'] == 'All day' ? true : false %}
+    {% set cal_link = calendar_link('ics', 'title', date(), date(), event_meta__all_day, 'description', 'location') %}
     {% include "@molecules/meta/event-meta/yds-event-meta.twig" with {
       event_meta__date_start: content.field_event_date.0.start['#text'].date['#markup'],
       event_meta__date_end: content.field_event_date.0.end['#text'].date['#markup'],
@@ -14,7 +15,7 @@
       event_meta__cta_primary__content: content.field_event_cta.0['#title'],
       event_meta__cta_primary__href: content.field_event_cta.0['#url_title'],
       event_meta__cta_secondary__content: 'Add to Calendar',
-      event_meta__cta_secondary__href: nothing_yet,
+      event_meta__cta_secondary__href: cal_link,
     } %}
   {% endblock %}
 {% endembed %}

--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -28,14 +28,22 @@
   'inperson': 'In-person',
   'In-person': 'In-person',
   'Online': 'Online',
+  'hybrid': 'Hybrid',
 }
 %}
 
 {# This sets the field event format to be what is expected from the component #}
 {% set field_event_format = node.field_event_format|map((object, _key) => labels[object.value]) %} 
 
+{#
+  The component is specifying the location as hybrid if multiple formats are
+  selected, so I decided to try to follow suit
+#}
+{% set isHybrid = field_event_format|length > 1 %}
+{% set calendar_location_text = isHybrid ? labels['hybrid'] : field_event_format|first %}
+
 {% set event_meta__all_day = (node.field_event_date.duration % all_day_duration) <= delta %}
-{% set cal_link = calendar_link('ics', node.title, start_datetime, end_datetime, event_meta__all_day, 'description', field_event_format) %}
+{% set cal_link = calendar_link('ics', node.title, start_datetime, end_datetime, event_meta__all_day, 'description', calendar_location_text) %}
 
 {% embed "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,

--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -35,7 +35,7 @@
 {% set field_event_format = node.field_event_format|map((object, _key) => labels[object.value]) %} 
 
 {% set event_meta__all_day = (node.field_event_date.duration % all_day_duration) <= delta %}
-{% set cal_link = calendar_link('ics', 'title', start_datetime, end_datetime, event_meta__all_day, 'description', field_event_format) %}
+{% set cal_link = calendar_link('ics', node.title, start_datetime, end_datetime, event_meta__all_day, 'description', field_event_format) %}
 
 {% embed "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,

--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -1,12 +1,30 @@
 {{ drupal_entity('block', 'yalesitesbreadcrumbs', check_access=false) }}
 
+{#
+  Please make this backend.  ;)
+  Is it worth me making this a hook?
+#}
+{# 
+  The duration that is set when you select "all day" 
+
+  This is done because smart date is not exposing to node whether you selected
+  all day or not
+#}
+{% set all_day_duration = 1439 %}
+
+{#
+  Since each all day day adds an extra minute, we create a delta based on the
+  number of days selected
+#}
+{% set delta = (node.field_event_date.duration // all_day_duration) %}
+
 {% embed "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
   page_title__width: 'content',
 } %}
   {% block page_title__meta %}
-    {% set event_meta__all_day = content.field_event_date.0.end['#text'].time['#markup'] == 'All day' ? true : false %}
     {% set cal_link = calendar_link('ics', 'title', date(), date(), event_meta__all_day, 'description', 'location') %}
+    {% set event_meta__all_day = (node.field_event_date.duration % all_day_duration) <= delta %}
     {% include "@molecules/meta/event-meta/yds-event-meta.twig" with {
       event_meta__date_start: node.field_event_date.value,
       event_meta__date_end: node.field_event_date.end_value,

--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -13,6 +13,8 @@
       event_meta__address: nothing_yet,
       event_meta__cta_primary__content: content.field_event_cta.0['#title'],
       event_meta__cta_primary__href: content.field_event_cta.0['#url_title'],
+      event_meta__cta_secondary__content: 'Add to Calendar',
+      event_meta__cta_secondary__href: nothing_yet,
     } %}
   {% endblock %}
 {% endembed %}

--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -18,13 +18,17 @@
 #}
 {% set delta = (node.field_event_date.duration // all_day_duration) %}
 
+{# Convert integers to datetime objects for use in calendar link #}
+{% set start_datetime = date(node.field_event_date.value|date_modify('+0 hour')) %}
+{% set end_datetime = date(node.field_event_date.end_value|date_modify('+0 hour')) %}
+
 {% embed "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
   page_title__width: 'content',
 } %}
   {% block page_title__meta %}
-    {% set cal_link = calendar_link('ics', 'title', date(), date(), event_meta__all_day, 'description', 'location') %}
     {% set event_meta__all_day = (node.field_event_date.duration % all_day_duration) <= delta %}
+    {% set cal_link = calendar_link('ics', 'title', start_datetime, end_datetime, event_meta__all_day, 'description', node.field_event_format.value) %}
     {% include "@molecules/meta/event-meta/yds-event-meta.twig" with {
       event_meta__date_start: node.field_event_date.value,
       event_meta__date_end: node.field_event_date.end_value,

--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -22,17 +22,30 @@
 {% set start_datetime = date(node.field_event_date.value|date_modify('+0 hour')) %}
 {% set end_datetime = date(node.field_event_date.end_value|date_modify('+0 hour')) %}
 
+{# I could not find where the lables are defined, so I had to create my own for now #}
+{% set labels = {
+  'online': 'Online',
+  'inperson': 'In-person',
+  'In-person': 'In-person',
+  'Online': 'Online',
+}
+%}
+
+{# This sets the field event format to be what is expected from the component #}
+{% set field_event_format = node.field_event_format|map((object, _key) => labels[object.value]) %} 
+
+{% set event_meta__all_day = (node.field_event_date.duration % all_day_duration) <= delta %}
+{% set cal_link = calendar_link('ics', 'title', start_datetime, end_datetime, event_meta__all_day, 'description', field_event_format) %}
+
 {% embed "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
   page_title__width: 'content',
 } %}
   {% block page_title__meta %}
-    {% set event_meta__all_day = (node.field_event_date.duration % all_day_duration) <= delta %}
-    {% set cal_link = calendar_link('ics', 'title', start_datetime, end_datetime, event_meta__all_day, 'description', node.field_event_format.value) %}
     {% include "@molecules/meta/event-meta/yds-event-meta.twig" with {
       event_meta__date_start: node.field_event_date.value,
       event_meta__date_end: node.field_event_date.end_value,
-      event_meta__format: node.field_event_format.value,
+      event_meta__format: field_event_format,
       event_meta__address: nothing_yet,
       event_meta__cta_primary__content: node.field_event_cta.title,
       event_meta__cta_primary__href: node.field_event_cta.uri,


### PR DESCRIPTION
## [YALB-1195: Events: Add to Calendar Link (BE)](https://yaleits.atlassian.net/browse/YALB-XX)

This PR is linked to the yalesites-project branch of the same name so that the calendar_link module can be pre-installed and activated.

### Description of work
- Use node object to pass data vs content as layout builder took it over
- Create DateTime representations of the start and end times given
- Use the calendar_link twig function module to create an ics calendar link with some placeholder data
- Create a calculation to determine if 'all day' could have been selected as the 'All day' selection from smart date is not in the node object
- Create a hopefully temporary way of displaying a "label" version of the selected format

### Functional testing steps:
- [ ] Add a new event page
- [ ] Fill out a title, select no format, enter a call to action link of your choice, and a date spanning a duration of an hour
- [ ] Save the page
- [ ] Verify that the title, date, and time displays correctly, and that the call to action link and the add to calendar link appear left below the date/time
- [ ] Click the `Add to Calendar` link
- [ ] Verify that it downloads a file
- [ ] When importing the file to your calendar, verify that the following are true:
  - [ ] Calendar title in your calendar matches the title you gave to the event
  - [ ] The date and time match on your calendar to the one you provided to the event
  - [ ] No location is set in your calendar
- [ ] Delete the calendar entry that was imported into your calendar
- [ ] Click `Setup` in the admin menu toward to the top of the screen
- [ ] Click `In-person` for format
- [ ] Span multiple days in the date portion
- [ ] Click `Save` in the upper right of the page
- [ ] Verify that the date now shows a span of days that you specified
- [ ] Verify that the call to action and add to calendar links are now on the right side of the event section
- [ ] Verify that you now see "In-person" to the left under the time
- [ ] Click "Add to Calendar"
- [ ] When importing the file to your calendar, verify that the following are true:
  - [ ] Calendar title in your calendar matches the title you gave to the event
  - [ ] The date and time match on your calendar to the ones you provided to the event
  - [ ] Location is set to `In-person`
- [ ] Delete the calendar entry that was imported into your calendar
- [ ] Click `Setup`
- [ ] Check 'Online'
- [ ] Under date, click the "All day" checkbox
- [ ] Slick `Save`
- [ ] Verify that you now see `Hybrid` to the left below text saying "All Day"
- [ ] Click `Add to Calendar`
- [ ] When importing the file to your calendar, verify that the following are true:
  - [ ] Calendar title in your calendar matches the title you gave to the event
  - [ ] The date/time specifies that it is an All Day event that spans the dates you selected previously
  - [ ] The location displays `Hybrid`
- [ ] Delete the calendar entry that was imported into your calendar