### PR TITLE
YALB-1205: Webform buttons: add preprocess to pass data-cta-theme attribute

### DIFF
--- a/templates/form/ys-search-form.html.twig
+++ b/templates/form/ys-search-form.html.twig
@@ -7,7 +7,12 @@
       control__element: 'input',
       cta__attributes: {
         'value': 'Search',
-        'type': 'submit'
+        'type': 'submit',
+        'data-cta-theme': getThemeSetting('button_theme'),
+        'data-cta-radius': 'none',
+        'data-cta-style': 'filled',
+        'data-cta-outline-weight': 2,
+        'data-cta-hover-style': 'fade',
       }
     } %}
   </div>


### PR DESCRIPTION
## [YALB-1205: Webform buttons: add preprocess to pass data-cta-theme attribute](https://yaleits.atlassian.net/browse/YALB-1205)

### Description of work
- Adds data attributes to search form to match selected button theme from settings
- Requires [Yalesites Project PR-271](https://github.com/yalesites-org/yalesites-project/pull/271)

### Functional testing steps:
- [ ] Testing steps here: https://github.com/yalesites-org/yalesites-project/pull/271
