### PR TITLE
YALB-1198: Events: Exposed filters on dynamic list (BE)

### DIFF
--- a/templates/form/form--views--event-list.html.twig
+++ b/templates/form/form--views--event-list.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Theme override for a 'form' element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the wrapper element.
+ * - children: The child elements of the form.
+ *
+ * @see template_preprocess_form()
+ */
+#}
+
+{%
+  set classes = [
+    'ys-filter-form',
+  ]
+%}
+
+<form{{ attributes.addClass(classes) }}>
+  {{ children }}
+</form>

--- a/templates/form/select.html.twig
+++ b/templates/form/select.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override for a select element.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the <select> tag.
+ * - options: The <option> element children.
+ *
+ * @see template_preprocess_select()
+ */
+#}
+{%
+  set classes = [
+    required ? 'js-form--required',
+    required ? 'form--required form-item__label--required',
+    'form-item__select',
+  ]
+%}
+
+{% apply spaceless %}
+  <div class="form-item__dropdown">
+    <select{{ attributes.addClass(classes) }}>
+      {% for option in options %}
+        {% if option.type == 'optgroup' %}
+          <optgroup label="{{ option.label }}">
+            {% for sub_option in option.options %}
+              <option value="{{ sub_option.value }}"{{ sub_option.selected ? ' selected="selected"' }}>{{ sub_option.label }}</option>
+            {% endfor %}
+          </optgroup>
+        {% elseif option.type == 'option' %}
+          <option value="{{ option.value }}"{{ option.selected ? ' selected="selected"' }}>{{ option.label }}</option>
+        {% endif %}
+      {% endfor %}
+    </select>
+  </div>
+{% endapply %}

--- a/templates/form/ys-search-form.html.twig
+++ b/templates/form/ys-search-form.html.twig
@@ -13,7 +13,8 @@
         'data-cta-style': 'filled',
         'data-cta-outline-weight': 2,
         'data-cta-hover-style': 'fade',
-      }
+      },
+      cta__content: 'Search',
     } %}
   </div>
 </form>

--- a/templates/views/views-view--event-list.html.twig
+++ b/templates/views/views-view--event-list.html.twig
@@ -11,7 +11,6 @@
     </header>
   {% endif %}
 
-  {{ exposed }}
   {{ attachment_before }}
 
   {% if rows -%}
@@ -20,6 +19,9 @@
       card_collection__featured: 'true',
       card_collection__type: 'list',
     } %}
+      {% block card_collection__filters %}
+        {{ exposed }}
+      {% endblock %}
       {% block card_collection__cards %}
         {{ rows }}
       {% endblock %}

--- a/templates/views/views-view--event-list.html.twig
+++ b/templates/views/views-view--event-list.html.twig
@@ -1,38 +1,42 @@
-{{ title_prefix }}
-{{ title }}
-{{ title_suffix }}
+{% set dom_id_class = dom_id ? 'js-view-dom-id-' ~ dom_id %}
 
-{% if header %}
-  <header>
-    {{ header }}
-  </header>
-{% endif %}
+<div class={{ dom_id_class }}>
+  {{ title_prefix }}
+  {{ title }}
+  {{ title_suffix }}
 
-{{ exposed }}
-{{ attachment_before }}
+  {% if header %}
+    <header>
+      {{ header }}
+    </header>
+  {% endif %}
 
-{% if rows -%}
-  {% embed "@organisms/card-collection/yds-card-collection.twig" with {
-    card_collection__heading: view.args.0,
-    card_collection__featured: 'true',
-    card_collection__type: 'list',
-  } %}
-    {% block card_collection__cards %}
-      {{ rows }}
-    {% endblock %}
-  {% endembed %}
-{% elseif empty -%}
-  {{ empty }}
-{% endif %}
-{{ pager }}
+  {{ exposed }}
+  {{ attachment_before }}
 
-{{ attachment_after }}
-{{ more }}
+  {% if rows -%}
+    {% embed "@organisms/card-collection/yds-card-collection.twig" with {
+      card_collection__heading: view.args.0,
+      card_collection__featured: 'true',
+      card_collection__type: 'list',
+    } %}
+      {% block card_collection__cards %}
+        {{ rows }}
+      {% endblock %}
+    {% endembed %}
+  {% elseif empty -%}
+    {{ empty }}
+  {% endif %}
+  {{ pager }}
 
-{% if footer %}
-  <footer>
-    {{ footer }}
-  </footer>
-{% endif %}
+  {{ attachment_after }}
+  {{ more }}
 
-{{ feed_icons }}
+  {% if footer %}
+    <footer>
+      {{ footer }}
+    </footer>
+  {% endif %}
+
+  {{ feed_icons }}
+</div>

--- a/templates/views/views-view--post-list.html.twig
+++ b/templates/views/views-view--post-list.html.twig
@@ -1,38 +1,42 @@
-{{ title_prefix }}
-{{ title }}
-{{ title_suffix }}
+{% set dom_id_class = dom_id ? 'js-view-dom-id-' ~ dom_id %}
 
-{% if header %}
-  <header>
-    {{ header }}
-  </header>
-{% endif %}
+<div class={{ dom_id_class }}>
+  {{ title_prefix }}
+  {{ title }}
+  {{ title_suffix }}
 
-{{ exposed }}
-{{ attachment_before }}
+  {% if header %}
+    <header>
+      {{ header }}
+    </header>
+  {% endif %}
 
-{% if rows -%}
-  {% embed "@organisms/card-collection/yds-card-collection.twig" with {
-    card_collection__heading: view.args.0,
-    card_collection__featured: 'true',
-    card_collection__type: 'list',
-  } %}
-    {% block card_collection__cards %}
-      {{ rows }}
-    {% endblock %}
-  {% endembed %}
-{% elseif empty -%}
-  {{ empty }}
-{% endif %}
-{{ pager }}
+  {{ exposed }}
+  {{ attachment_before }}
 
-{{ attachment_after }}
-{{ more }}
+  {% if rows -%}
+    {% embed "@organisms/card-collection/yds-card-collection.twig" with {
+      card_collection__heading: view.args.0,
+      card_collection__featured: 'true',
+      card_collection__type: 'list',
+    } %}
+      {% block card_collection__cards %}
+        {{ rows }}
+      {% endblock %}
+    {% endembed %}
+  {% elseif empty -%}
+    {{ empty }}
+  {% endif %}
+  {{ pager }}
 
-{% if footer %}
-  <footer>
-    {{ footer }}
-  </footer>
-{% endif %}
+  {{ attachment_after }}
+  {{ more }}
 
-{{ feed_icons }}
+  {% if footer %}
+    <footer>
+      {{ footer }}
+    </footer>
+  {% endif %}
+
+  {{ feed_icons }}
+</div>


### PR DESCRIPTION
## [YALB-1198: Events: Exposed filters on dynamic list (BE)](https://yaleits.atlassian.net/browse/YALB-1198)

### Description of work
- Adds markup to support ajax filtering for views for Calendar List.
- Main testing instructions here: https://github.com/yalesites-org/yalesites-project/pull/276
- Multidev here: https://pr-276-yalesites-platform.pantheonsite.io/

### Functional testing steps:
- [x] When testing the "Calendar List" (the built in block, not views), verify that by changing the event category and clicking "Apply" will use Ajax to refresh the results and not perform a full page refresh.