### PR TITLE
YALB-609: Page lists and grid display modes

### DIFF
--- a/templates/node/node--page--card.html.twig
+++ b/templates/node/node--page--card.html.twig
@@ -1,0 +1,21 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__heading: heading,
+  reference_card__subheading: date__formatted,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image: 'true',
+} %}
+  {% block reference_card__image %}
+
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
+    {% endif %}
+
+  {% endblock %}
+{% endembed %}

--- a/templates/node/node--page--list-item.html.twig
+++ b/templates/node/node--page--list-item.html.twig
@@ -3,7 +3,6 @@
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 
 {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
-  reference_card__overline: date__formatted,
   reference_card__heading: heading,
   reference_card__url: url,
   reference_card__snippet: content.field_teaser_text,

--- a/templates/node/node--page--list-item.html.twig
+++ b/templates/node/node--page--list-item.html.twig
@@ -1,0 +1,20 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__overline: date__formatted,
+  reference_card__heading: heading,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+} %}
+  {% block reference_card__image %}
+
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
+    {% endif %}
+
+  {% endblock %}
+{% endembed %}


### PR DESCRIPTION
## [YALB-609: Page lists and grid display modes](https://yaleits.atlassian.net/browse/YALB-609)

### Description of work
- Adds templates for `page--list` and `page--card`

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/287
- [ ] Verify templates render as they should