### PR TITLE
YALB-1197: Media: Allow embed of SoundCloud content (BE)

### DIFF
--- a/templates/ys_embed/broken.html.twig
+++ b/templates/ys_embed/broken.html.twig
@@ -1,0 +1,1 @@
+Broken/Missing

--- a/templates/ys_embed/embed_wrapper.html.twig
+++ b/templates/ys_embed/embed_wrapper.html.twig
@@ -1,0 +1,9 @@
+{% set embed_wrapper__embed_type = display_attributes['embed_type']|default('unknown') %}
+{% set embed_wrapper__width = display_attributes['width']|default('100%') %}
+{% set embed_wrapper__height = display_attributes['height']|default('100%') %}
+
+{% if display_attributes['isIframe'] %}
+    <iframe data-embed-type="{{ embed_wrapper__embed_type }}" src="{{ url }}" title="{{ title }}" width="{{ embed_wrapper__width }}" height="{{ embed_wrapper__height }}"></iframe>
+{% else %}
+    {{ embedSource }}
+{% endif %}

--- a/templates/ys_embed/embed_wrapper.html.twig
+++ b/templates/ys_embed/embed_wrapper.html.twig
@@ -1,9 +1,17 @@
 {% set embed_wrapper__embed_type = displayAttributes['embedType']|default('unknown') %}
-{% set embed_wrapper__width = displayAttributes['width']|default('100%') %}
+{% set embed_wrapper__width = displayAttributes['width']|default('site') %}
 {% set embed_wrapper__height = displayAttributes['height']|default('100%') %}
 
 {% if displayAttributes['isIframe'] %}
-    <iframe data-embed-type="{{ embed_wrapper__embed_type }}" src="{{ url }}" title="{{ title }}" width="{{ embed_wrapper__width }}" height="{{ embed_wrapper__height }}"></iframe>
+    <div data-embedded-components>
+        {% embed "@molecules/embed/yds-embed.twig" with {
+            embed__src: url,
+            embed__title: title,
+            embed__width: embed_wrapper__width,
+            embed__type: embed_wrapper__embed_type,
+        } %}
+        {% endembed %}
+    </div>
 {% else %}
     {{ embedSource }}
 {% endif %}

--- a/templates/ys_embed/embed_wrapper.html.twig
+++ b/templates/ys_embed/embed_wrapper.html.twig
@@ -1,8 +1,8 @@
-{% set embed_wrapper__embed_type = display_attributes['embed_type']|default('unknown') %}
-{% set embed_wrapper__width = display_attributes['width']|default('100%') %}
-{% set embed_wrapper__height = display_attributes['height']|default('100%') %}
+{% set embed_wrapper__embed_type = displayAttributes['embedType']|default('unknown') %}
+{% set embed_wrapper__width = displayAttributes['width']|default('100%') %}
+{% set embed_wrapper__height = displayAttributes['height']|default('100%') %}
 
-{% if display_attributes['isIframe'] %}
+{% if displayAttributes['isIframe'] %}
     <iframe data-embed-type="{{ embed_wrapper__embed_type }}" src="{{ url }}" title="{{ title }}" width="{{ embed_wrapper__width }}" height="{{ embed_wrapper__height }}"></iframe>
 {% else %}
     {{ embedSource }}

--- a/templates/ys_embed/instagram.html.twig
+++ b/templates/ys_embed/instagram.html.twig
@@ -1,0 +1,1 @@
+<blockquote {{ embed_code|raw }}</blockquote> <script async src="//www.instagram.com/embed.js"></script>

--- a/templates/ys_embed/powerbi.html.twig
+++ b/templates/ys_embed/powerbi.html.twig
@@ -1,0 +1,1 @@
+<iframe class="iframe" title="{{ title }}" src="https://app.powerbi.com/view{{ form_params }}" height="100%" width="100%" loading="lazy"></iframe>

--- a/templates/ys_embed/qualtrics.html.twig
+++ b/templates/ys_embed/qualtrics.html.twig
@@ -1,0 +1,1 @@
+<iframe class="iframe" title="{{ title }}" src="https://yalesurvey.ca1.qualtrics.com/jfe/form/{{ form_id }}" height="100%" width="100%" loading="lazy"></iframe>

--- a/templates/ys_embed/soundcloud.html.twig
+++ b/templates/ys_embed/soundcloud.html.twig
@@ -1,10 +1,10 @@
 {% set soundcloud__base_class = soundcloud__base_class|default('ys-embed-soundcloud') %}
-{% set soundcloud__width = "content" %}
-{% set soundcloud__alignment = "left" %}
+{% set soundcloud__width = soundcloud__width|default('content') %}
+{% set soundcloud__alignment = soundcloud__alignment|default('left') %}
 
 {% set soundcloud_embed__attributes = {
-    'data-component-width': soundcloud__width|default('content'),
-    'data-component-alignment': soundcloud__alignment|default('left'),
+    'data-component-width': soundcloud__width,
+    'data-component-alignment': soundcloud__alignment,
     class: bem(soundcloud__base_class, soundcloud__modifiers),
 } %}
 

--- a/templates/ys_embed/soundcloud.html.twig
+++ b/templates/ys_embed/soundcloud.html.twig
@@ -1,0 +1,18 @@
+{% set soundcloud__base_class = soundcloud__base_class|default('ys-embed-soundcloud') %}
+{% set soundcloud__width = "content" %}
+{% set soundcloud__alignment = "left" %}
+
+{% set soundcloud_embed__attributes = {
+    'data-component-width': soundcloud__width|default('content'),
+    'data-component-alignment': soundcloud__alignment|default('left'),
+    class: bem(soundcloud__base_class, soundcloud__modifiers),
+} %}
+
+<div {{ add_attributes(soundcloud_embed__attributes) }}>
+    {% embed "@molecules/embed/yds-embed.twig" with {
+        embed__src: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/#{track_id}&color=%02366900&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true",
+        embed__title: title,
+    } %}
+    {% endembed %}
+</div>
+

--- a/templates/ys_embed/soundcloud.html.twig
+++ b/templates/ys_embed/soundcloud.html.twig
@@ -9,10 +9,6 @@
 } %}
 
 <div {{ add_attributes(soundcloud_embed__attributes) }}>
-    {% embed "@molecules/embed/yds-embed.twig" with {
-        embed__src: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/#{track_id}&color=%02366900&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true",
-        embed__title: title,
-    } %}
-    {% endembed %}
+    <iframe title="{{ title }}" width="100%" height="240px" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/{{ track_id }}&color=%02366900&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>
 </div>
 

--- a/templates/ys_embed/twitter.html.twig
+++ b/templates/ys_embed/twitter.html.twig
@@ -1,0 +1,2 @@
+{{ blockquote|raw }}
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
## [YALB-1197: Media: Allow embed of SoundCloud content (BE)](https://yaleits.atlassian.net/browse/YALB-1197)

To be tested in tandem with [Yalesites PR 269](https://github.com/yalesites-org/yalesites-project/pull/269)

### Description of work
- Add new template overload for ys_embed's embed_wrapper to allow embeds to work in pre-configured iframe or legacy inline_templates.

### Functional testing steps:
- [ ] Create one of each embed in the instructions
- [ ] Verify that they look correct
- [ ] Verify that SoundCloud's height is smaller than that of items like PowerBI