### PR TITLE
YALB-1230: Create Topics vocabulary for Posts

### DIFF
--- a/templates/form/form--views--post-list.html.twig
+++ b/templates/form/form--views--post-list.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Theme override for a 'form' element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the wrapper element.
+ * - children: The child elements of the form.
+ *
+ * @see template_preprocess_form()
+ */
+#}
+
+{%
+  set classes = [
+    'ys-filter-form',
+  ]
+%}
+
+<form{{ attributes.addClass(classes) }}>
+  {{ children }}
+</form>

--- a/templates/views/views-view--post-list.html.twig
+++ b/templates/views/views-view--post-list.html.twig
@@ -11,7 +11,6 @@
     </header>
   {% endif %}
 
-  {{ exposed }}
   {{ attachment_before }}
 
   {% if rows -%}
@@ -20,6 +19,9 @@
       card_collection__featured: 'true',
       card_collection__type: 'list',
     } %}
+      {% block card_collection__filters %}
+        {{ exposed }}
+      {% endblock %}
       {% block card_collection__cards %}
         {{ rows }}
       {% endblock %}


### PR DESCRIPTION
## [YALB-1230: Create Topics vocabulary for Posts](https://yaleits.atlassian.net/browse/YALB-1230)

### Description of work
- Adds templates to add exposed filters to post lists
- Note: Incorrectly referenced YALB-1232 in commits, should have been YALB-1230.

### Functional testing steps:
- [ ] See testing steps in [PR-292](https://github.com/yalesites-org/yalesites-project/pull/292)