### PR TITLE
YALB-1288: Bug: Search no results message (BE)

### DIFF
--- a/templates/views/views-view--search.html.twig
+++ b/templates/views/views-view--search.html.twig
@@ -25,7 +25,12 @@
       {% if rows -%}
         {{ rows }}
       {% elseif empty -%}
-        {{ empty }}
+        {% if view.args.0 %}
+          {{ empty }}
+        {% else %}
+          {{ "Enter some search terms and then click submit."|trans }}
+        {% endif %}
+
       {% endif %}
       {{ pager }}
 

--- a/templates/views/views-view--search.html.twig
+++ b/templates/views/views-view--search.html.twig
@@ -28,7 +28,7 @@
         {% if view.args.0 %}
           {{ empty }}
         {% else %}
-          {{ "Enter some search terms and then click submit."|trans }}
+          {{ "Enter some search terms and then click search."|trans }}
         {% endif %}
 
       {% endif %}


### PR DESCRIPTION
## [YALB-1288: Bug: Search no results message (BE)](https://yaleits.atlassian.net/browse/YALB-1288)

### Description of work
- Fixes bug where no results text wasn't showing properly.
- No results text will now show if search terms are entered and no results are found.
- New search text will now show if no search terms are entered. (i.e. on /search with no keywords query parameter)
- Requires [PR-320](https://github.com/yalesites-org/yalesites-project/pull/320)

### Functional testing steps:
- [ ] [Main testing steps over on PR-320](https://github.com/yalesites-org/yalesites-project/pull/320)
