### PR TITLE
YALB-1317: Bug: Paragraph duplicate function broken (BE)

### DIFF
--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -11,17 +11,25 @@
   {% endfor %}
 {% elseif item_variation == 'modal' %}
 
+{#
+  Note: The below check for 'not iterable' is what prevents an error when
+  duplicating paragraphs or attempting to preview modal contents of a newly
+  created paragraph prior to save. This is because the paragraph ID has not
+  yet been created and so cannot be passed to the twig_tweak function.
+#}
+
   {% embed "@organisms/galleries/media-grid/_yds-media-grid-modal-item.twig" with {
     media_grid__items: content.field_gallery_items['#items'],
   } %}
     {% block media_grid__modal__media %}
-      {% if not item.entity.id.0.value %}
-        <p>Preview will be available after save.</p>
+      {% if item.entity.id.0.value is not iterable %}
+        {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_media') }}
       {% endif %}
-      {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_media') }}
     {% endblock %}
     {% block media_grid__modal__content %}
-      {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_content') }}
+      {% if item.entity.id.0.value is not iterable %}
+        {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_content') }}
+      {% endif %}
     {% endblock %}
   {% endembed %}
 {% endif %}


### PR DESCRIPTION
## [YALB-1317: Bug: Paragraph duplicate function broken (BE)](https://yaleits.atlassian.net/browse/YALB-1317)

### Description of work
- Fixes error when duplicating gallery item paragraphs
- Main repo is not required for this work, only Atomic.

### Functional testing steps:
- [ ] Main testing step over on [PR-322](https://github.com/yalesites-org/yalesites-project/pull/322)