### PR TITLE
YALB-1251 - AX: pencil icon difficulty editing blocks | YALB-1261 - Bug: A11y color issue in rollover menu (FE)

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -292,6 +292,7 @@ table .draggable-table.tabledrag-disabled tr:hover {
   text-decoration: underline;
 }
 
+.text table tr:hover,
 .layout-builder-components-table tr:hover {
   color: var(--darkest-gray);
 }

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -284,3 +284,54 @@ table .draggable-table.tabledrag-disabled tr:hover {
 .layout-builder__link--remove {
   --gin-border-color-form-element: var(--darkest-gray); 
 }
+
+/* yalb-1261 - fix hover color on table */
+
+.layout-builder-components-table__block-label:hover {
+  color: var(--darkest-gray);
+  text-decoration: underline;
+}
+ 
+/* yalb-1251 - AX: pencil icon difficulty editing blocks */
+/* change the contextual pencil icon to the left-hand side of each component
+// instead of the right
+*/
+.layout-builder-block.contextual-region .contextual {
+  top: 1rem;
+  left: 0;
+  width: 20%;
+}
+
+.layout-builder-block.contextual-region .contextual .contextual-links {
+  left: 6px;
+  float: right;
+}
+
+/* increase the size of the clickable/hoverable area */
+.layout-builder-block.contextual-region .contextual .trigger {  
+  width: 50px !important;
+  height: 50px !important;
+}
+
+/* increase the size of the icon itself */
+.layout-builder-block.contextual-region .contextual .trigger::before {
+  width: 1.2rem;
+  height: 1.2rem;
+  mask-size: 1.2rem;
+}
+
+/* add min-height so that smaller (in height) components are more easily
+// able to be interacted with - e.g. `divider`
+*/
+.layout-builder-block {
+  min-height: 6rem;
+}
+
+/* increase padding around the divider when in layout-builder, to make the
+// divider more visible
+*/
+.layout-builder-block .divider__wrapper {
+  display: flex;
+  align-items: center;
+  padding-inline: 2rem;
+}

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -292,9 +292,13 @@ table .draggable-table.tabledrag-disabled tr:hover {
   text-decoration: underline;
 }
 
-.text table tr:hover,
 .layout-builder-components-table tr:hover {
   color: var(--darkest-gray);
+}
+
+/* yalb-1296 - table tr hover in text component */
+.text table tr:hover {
+  color: var(--color-text);
 }
  
 /* yalb-1251 - AX: pencil icon difficulty editing blocks */

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -291,6 +291,10 @@ table .draggable-table.tabledrag-disabled tr:hover {
   color: var(--darkest-gray);
   text-decoration: underline;
 }
+
+.layout-builder-components-table tr:hover {
+  color: var(--darkest-gray);
+}
  
 /* yalb-1251 - AX: pencil icon difficulty editing blocks */
 /* change the contextual pencil icon to the left-hand side of each component

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -301,14 +301,30 @@ table .draggable-table.tabledrag-disabled tr:hover {
 // instead of the right
 */
 .layout-builder-block.contextual-region .contextual {
+  display: flex;
+  flex-direction: column;
   top: 1rem;
-  left: 0;
-  width: 20%;
+  left: 2vw;
+  right: auto;
+  width: auto;
 }
 
+@media only screen and (min-width: 2200px) {
+  .layout-builder-block.contextual-region .contextual {
+    left: 15vw;
+  }
+} 
+
+@media only screen and (min-width: 2500px) {
+  .layout-builder-block.contextual-region .contextual {
+    left: 20vw;
+  }
+} 
+
 .layout-builder-block.contextual-region .contextual .contextual-links {
-  left: 6px;
-  float: right;
+  left: 0;
+  right: 0;
+  float: unset;
 }
 
 /* increase the size of the clickable/hoverable area */
@@ -322,6 +338,7 @@ table .draggable-table.tabledrag-disabled tr:hover {
   width: 1.2rem;
   height: 1.2rem;
   mask-size: 1.2rem;
+  -webkit-mask-size: 1.2rem;
 }
 
 /* add min-height so that smaller (in height) components are more easily


### PR DESCRIPTION
## [YALB-1251 - AX: pencil icon difficulty editing blocks](https://yaleits.atlassian.net/browse/YALB-1251) | [YALB-1261 - Bug: A11y color issue in rollover menu (FE)](https://yaleits.atlassian.net/browse/YALB-1261)

### Description of work
- Increase size of the contextual button on each component along with the size of the pencil icon
- Move the contextual button from the right-hand side of the screen to the left
- Fixes the appearance of "Move" table item labels on `:hover`

### Functional testing steps:
- [ ] Pull down branch
- [ ] Clear cache

#### Testing YALB-1251 - AX: pencil icon difficulty editing blocks
- [ ] Login and edit a page like this (using layout builder) https://yalesites-platform.lndo.site/node/8/layout
- [ ] As you hover over the component on the page, verify the `pencil` icon is larger, the circle around it is larger, and it has been moved from the right-hand side of the screen to the left.
- [ ] Add a `divider` component to the page and verify it is much easier to hover over and interact with. 
- [ ] Add a `button` component to the page and verify it is much easier to hover over and interact with. 
- see video example below

---

#### Testing YALB-1261 - Bug: A11y color issue in rollover menu (FE)
- [ ] Click the pencil icon next to a component and select `move`
- [ ] Verify that when you hover over items in the presented table of labels to re-organize items on the page, each item is dark gray and indicates hover by `text-decoration: underline`.
- see video example below

---

### Video showcasing all fixes:

https://github.com/yalesites-org/atomic/assets/366413/b4ecd236-4bc5-4663-a160-6819a4efa4bb



