### PR TITLE
YALB-1418: Bug: All events created are showing as past events

### DIFF
--- a/templates/node/node--event--full.html.twig
+++ b/templates/node/node--event--full.html.twig
@@ -44,22 +44,16 @@
   {% set cal_text = 'Add to Calendar' %}
 {% endif %}
 
-{% embed "@molecules/page-title/yds-page-title.twig" with {
-  page_title__heading: label,
-  page_title__width: 'content',
+{% include "@molecules/meta/event-meta/yds-event-meta.twig" with {
+  event_title__heading: label,
+  event_meta__date_start: component_date_start,
+  event_meta__date_end: component_date_end,
+  event_meta__format: format_labels,
+  event_meta__address: nothing_yet,
+  event_meta__cta_primary__content: node.field_event_cta.title,
+  event_meta__cta_primary__href: node.field_event_cta.0.getUrl().toString(),
+  event_meta__cta_secondary__content: cal_text,
+  event_meta__cta_secondary__href: cal_link,
 } %}
-  {% block page_title__meta %}
-    {% include "@molecules/meta/event-meta/yds-event-meta.twig" with {
-      event_meta__date_start: component_date_start,
-      event_meta__date_end: component_date_end,
-      event_meta__format: format_labels,
-      event_meta__address: nothing_yet,
-      event_meta__cta_primary__content: node.field_event_cta.title,
-      event_meta__cta_primary__href: node.field_event_cta.0.getUrl().toString(),
-      event_meta__cta_secondary__content: cal_text,
-      event_meta__cta_secondary__href: cal_link,
-    } %}
-  {% endblock %}
-{% endembed %}
 
 {{ content|without('field_event_date', 'field_event_format', 'field_event_cta') }}


### PR DESCRIPTION
## [YALB-1418: Bug: All events created are showing as past events](https://yaleits.atlassian.net/browse/YALB-1418)

### Description of work
- Removes page-title embed in favor of pulling in the `yds-event-meta` with `event_title__heading` mapped to `label` so that the page title renders where it should render instead of causing an empty `h1` accessibility error - and rendering the page title above where it need to be.

### Functional testing steps:
- [x] Test with https://github.com/yalesites-org/component-library-twig/pull/259
- [x] Make sure the `Past Event` prefix behavior works as expected. 

![Screenshot-20230628152427-2458x899](https://github.com/yalesites-org/atomic/assets/366413/42f0a44c-67b6-463e-bb12-122aabb8910a)
