### PR TITLE
YALB-1295: Bug: Posts display date of creation and not Publish Date

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -72,6 +72,8 @@ function atomic_theme_suggestions_container_alter(array &$suggestions, array &$v
  * Implements hook_preprocess_node().
  */
 function atomic_preprocess_node(&$variables) {
-  $date = $variables['node']->getCreatedTime();
-  $variables['date_formatted'] = \Drupal::service('date.formatter')->format($date, '', 'c');
+  if ($variables['node']->getType() == 'post') {
+    $date = strtotime($variables['node']->field_publish_date->first()->getValue()['value']);
+    $variables['date_formatted'] = \Drupal::service('date.formatter')->format($date, '', 'c');
+  }
 }

--- a/templates/node/node--post--full.html.twig
+++ b/templates/node/node--post--full.html.twig
@@ -2,7 +2,7 @@
 
 {% include "@molecules/page-title/yds-page-title.twig" with {
   page_title__heading: label,
-  page_title__meta: content.field_author|render ~ date,
+  page_title__meta: content.field_author|render ~ date_formatted|date("l, F j, Y"),
   page_title__width: 'content',
 } %}
 


### PR DESCRIPTION
## [YALB-1295: Bug: Posts display date of creation and not Publish Date](https://yaleits.atlassian.net/browse/YALB-1295)

### Description of work
- Changes the visual display of the post date (in cards, lists, and default node view) from the creation date to the date in the "Publish Date" field.
- Also part of [PR-332](https://github.com/yalesites-org/yalesites-project/pull/332)

### Functional testing steps:
- [ ] All testing steps located over on [PR-332](https://github.com/yalesites-org/yalesites-project/pull/332)
