### PR TITLE
YALB-1419 - OPAC: Move admin toolbar to top

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -111,6 +111,10 @@
   top: calc(var(--gin-toolbar-secondary-height) - 7px) !important;
 }
 
+body.gin--horizontal-toolbar {
+  padding-top: calc(var(--gin-toolbar-y-offset) + var(--gin-toolbar-secondary-height)) !important;
+}
+
 [data-gin-accent=light_blue] .ui-widget-overlay {
   background: var(--peacock-green) !important;
 }

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -105,7 +105,10 @@
 }
 
 .gin-secondary-toolbar--frontend {
+  position: fixed;
   background-color: var(--gin-bg-layer);
+  width: 100%;
+  top: calc(var(--gin-toolbar-secondary-height) - 7px) !important;
 }
 
 [data-gin-accent=light_blue] .ui-widget-overlay {


### PR DESCRIPTION
## [YALB-1419 - OPAC: Move admin toolbar to top](https://yaleits.atlassian.net/browse/YALB-1419)

### Description of work
- Adds styles to make the secondary-toolbar sticky.

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/345
