### PR TITLE
YALB-1396: Bug: Grand Hero - Pause/play button mobile responsiveness | YALB-1398: Bug: Mega Menu on Tablet | YALB-1405-Bug: Last item drop down in simple menu alignment on center nav | YALB-1287: Confirm fix: Short Banner Height Issue | YALB-1433: Bug: Gallery does not work when on the same page as a media grid

### DIFF
--- a/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
+++ b/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
@@ -10,8 +10,8 @@
     grand_hero__link__content: content.field_link.0['#title'],
     grand_hero__link__url: content.field_link.0['#url_title'],
     grand_hero__content__background: content.field_style_color.0['#markup'],
-    grand_hero__overlay_variation: content.field_style_variation.0['#markup'],
-    grand_hero__size: content.field_style_position.0['#markup'],
+    grand_hero__overlay_variation: content.field_style_position.0['#markup'],
+    grand_hero__size: content.field_style_variation.0['#markup'],
     grand_hero__width: 'site',
   } %}
     {% block grand_hero__video %}


### PR DESCRIPTION
### Tickets: 

- [YALB-1396: Bug: Grand Hero - Pause/play button mobile responsiveness](https://yaleits.atlassian.net/browse/YALB-1396) 
- [YALB-1398: Bug: Mega Menu on Tablet](https://yaleits.atlassian.net/browse/YALB-1398) 
- [YALB-1405-Bug: Last item drop down in simple menu alignment on center nav](https://yaleits.atlassian.net/browse/YALB-1405)
- [YALB-1287: Confirm fix: Short Banner Height Issue](https://yaleits.atlassian.net/browse/YALB-1287)
- [YALB-1433: Bug: Gallery does not work when on the same page as a media grid](https://yaleits.atlassian.net/browse/YALB-1433)

### Description of work
- Maps the correct fields to their data attributes
- For the sake of documentation, this is

```
grand_hero:
  field_style_position:
    values:
      full: Full
      contained: 'Floating Box'
    default: full
  field_style_variation:
    values:
      full: Tall
      reduced: Short
    default: full
```

```
field_style_position =  grand_hero__overlay_variation: content.field_style_position.0['#markup'],

Values should be: `full` and `contained`
```

```
field_style_variation =  grand_hero__size: content.field_style_variation.0['#markup'],

Values should be: `full` and `reduced`
```


### Functional testing steps:
- [x] Test as part of this ticket here: https://github.com/yalesites-org/yalesites-project/pull/350
- [x] The original mapping of fields was correct. When I changed it a few months ago, that was wrong. The `yml` file changes were correct. 