### PR TITLE
YALB-1407- Bug: Accessibility (FE)- Interactive Media needs roles and tabbing fixes | YALB-1454 - Bug: FE: Quote em dash and name alignment off

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -57,3 +57,19 @@ need to have margin-bottom set to 0 */
 .main-content .layout.layout--onecol:last-child {
   margin-bottom: 0;
 }
+
+/*
+// Pull quotes has a <p> element provided by the WYSIWYG 
+// we need to make the `-` character and the attribution text in line, 
+// and remove margin from the <p>
+display: flex;
+*/
+
+.pull-quote__attribution {
+  display: flex;
+}
+
+.pull-quote__attribution p {
+  margin-top: 0;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## [YALB-1407- Bug: Accessibility (FE)- Interactive Media needs roles and tabbing fixes](https://yaleits.atlassian.net/browse/YALB-1407) | [YALB-1454 - Bug: FE: Quote em dash and name alignment off](https://yaleits.atlassian.net/browse/YALB-1454)

### Description of work
- Adds quote-specific styles to our Atomic `layout-builder.css` file
- The `p` element isn't part of our design system, so we should include the css here instead of in the component-library

### Functional testing steps:
- Test here: https://github.com/yalesites-org/component-library-twig/pull/275
