### PR TITLE
YALB-1394: Bug: Accessibility (FE)- Empty heading being inserted when user does not fill in heading field

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -84,10 +84,10 @@ function atomic_preprocess_node(&$variables) {
  * Inject the heading_level based on the parent's heading presence.
  */
 function atomic_preprocess_paragraph__accordion_item(&$variables) {
-  $accordion = $variables['paragraph']->getParentEntity();
-
-  if ($accordion->hasField('field_heading')) {
-    $heading = $accordion->field_heading->value;
-    $variables['attributes']['heading_level'] = empty($heading) ? 2 : 3;
+  if ($accordion = $variables['paragraph']->getParentEntity()) {
+    if ($accordion->hasField('field_heading')) {
+      $heading = $accordion->field_heading->value;
+      $variables['attributes']['heading_level'] = empty($heading) ? 2 : 3;
+    }
   }
 }

--- a/atomic.theme
+++ b/atomic.theme
@@ -8,14 +8,16 @@
 /**
  * Implements hook_preprocess_region().
  */
-function atomic_preprocess_region(&$variables) {
+function atomic_preprocess_region(&$variables)
+{
   $variables['site_name'] = \Drupal::config('system.site')->get('name');
 }
 
 /**
  * Implements hook_preprocess_menu().
  */
-function atomic_preprocess_menu(&$variables, $hook) {
+function atomic_preprocess_menu(&$variables, $hook)
+{
   $current_path = \Drupal::request()->getRequestUri();
   $items = $variables['items'];
   foreach ($items as $key => $item) {
@@ -45,7 +47,8 @@ function atomic_preprocess_menu(&$variables, $hook) {
 /**
  * Implements hook_theme_suggestions_hook_alter() for containers.
  */
-function atomic_theme_suggestions_container_alter(array &$suggestions, array &$variables) {
+function atomic_theme_suggestions_container_alter(array &$suggestions, array &$variables)
+{
   $type = '';
   $name = '';
 
@@ -71,9 +74,24 @@ function atomic_theme_suggestions_container_alter(array &$suggestions, array &$v
 /**
  * Implements hook_preprocess_node().
  */
-function atomic_preprocess_node(&$variables) {
+function atomic_preprocess_node(&$variables)
+{
   if ($variables['node']->getType() == 'post') {
     $date = strtotime($variables['node']->field_publish_date->first()->getValue()['value']);
     $variables['date_formatted'] = \Drupal::service('date.formatter')->format($date, '', 'c');
+  }
+}
+
+/**
+ * Implements hook_preprocess_paragraph__accordion_item().
+ * Inject the heading_level based on the parent's heading presence.
+ */
+function atomic_preprocess_paragraph__accordion_item(&$variables)
+{
+  $accordion = $variables['paragraph']->getParentEntity();
+
+  if ($accordion->hasField('field_heading')) {
+    $heading = $accordion->field_heading->value;
+    $variables['attributes']['heading_level'] = empty($heading) ? 2 : 3;
   }
 }

--- a/atomic.theme
+++ b/atomic.theme
@@ -8,16 +8,14 @@
 /**
  * Implements hook_preprocess_region().
  */
-function atomic_preprocess_region(&$variables)
-{
+function atomic_preprocess_region(&$variables) {
   $variables['site_name'] = \Drupal::config('system.site')->get('name');
 }
 
 /**
  * Implements hook_preprocess_menu().
  */
-function atomic_preprocess_menu(&$variables, $hook)
-{
+function atomic_preprocess_menu(&$variables, $hook) {
   $current_path = \Drupal::request()->getRequestUri();
   $items = $variables['items'];
   foreach ($items as $key => $item) {
@@ -47,8 +45,7 @@ function atomic_preprocess_menu(&$variables, $hook)
 /**
  * Implements hook_theme_suggestions_hook_alter() for containers.
  */
-function atomic_theme_suggestions_container_alter(array &$suggestions, array &$variables)
-{
+function atomic_theme_suggestions_container_alter(array &$suggestions, array &$variables) {
   $type = '';
   $name = '';
 
@@ -74,8 +71,7 @@ function atomic_theme_suggestions_container_alter(array &$suggestions, array &$v
 /**
  * Implements hook_preprocess_node().
  */
-function atomic_preprocess_node(&$variables)
-{
+function atomic_preprocess_node(&$variables) {
   if ($variables['node']->getType() == 'post') {
     $date = strtotime($variables['node']->field_publish_date->first()->getValue()['value']);
     $variables['date_formatted'] = \Drupal::service('date.formatter')->format($date, '', 'c');
@@ -84,10 +80,10 @@ function atomic_preprocess_node(&$variables)
 
 /**
  * Implements hook_preprocess_paragraph__accordion_item().
+ *
  * Inject the heading_level based on the parent's heading presence.
  */
-function atomic_preprocess_paragraph__accordion_item(&$variables)
-{
+function atomic_preprocess_paragraph__accordion_item(&$variables) {
   $accordion = $variables['paragraph']->getParentEntity();
 
   if ($accordion->hasField('field_heading')) {

--- a/templates/block/layout-builder/block--inline-block--gallery.html.twig
+++ b/templates/block/layout-builder/block--inline-block--gallery.html.twig
@@ -11,7 +11,7 @@
   {% endif %}
 
   {% embed "@organisms/galleries/media-grid/yds-media-grid.twig" with {
-    media_grid__heading: content.field_heading,
+    media_grid__heading: content.field_heading.0,
     media_grid__variation: 'interactive',
     media_grid__width: media_grid__width,
   } %}

--- a/templates/block/layout-builder/block--inline-block--media-grid.html.twig
+++ b/templates/block/layout-builder/block--inline-block--media-grid.html.twig
@@ -8,7 +8,7 @@
   {% endif %}
 
   {% embed "@organisms/galleries/media-grid/yds-media-grid.twig" with {
-    media_grid__heading: content.field_heading,
+    media_grid__heading: content.field_heading.0,
     media_grid__width: media_grid__width,
   } %}
 

--- a/templates/block/layout-builder/block--inline-block--video.html.twig
+++ b/templates/block/layout-builder/block--inline-block--video.html.twig
@@ -11,7 +11,7 @@
   {% endif %}
 
   {% embed "@molecules/video/yds-video.twig" with {
-    video__heading: content.field_heading,
+    video__heading: content.field_heading.0,
     video__text: content.field_text,
     video__width: video__width|default('site'),
     video__alignment: video__alignment|default('left'),

--- a/templates/paragraphs/paragraph--accordion-item.html.twig
+++ b/templates/paragraphs/paragraph--accordion-item.html.twig
@@ -1,5 +1,5 @@
 {% include "@molecules/accordion/_yds-accordion-item.twig" with {
   accordion__item__heading: content.field_heading,
   accordion__item__content: content.field_content,
-  accordion__item__heading__level: 3
+  accordion__item__heading__level: attributes.heading_level|default(3),
 } %}

--- a/templates/paragraphs/paragraph--gallery-item--gallery-modal-content.html.twig
+++ b/templates/paragraphs/paragraph--gallery-item--gallery-modal-content.html.twig
@@ -1,4 +1,4 @@
 {% include "@organisms/galleries/media-grid/_yds-media-grid-modal-item--content.twig" with {
-  modal_item__heading: content.field_heading,
+  modal_item__heading: content.field_heading.0,
   modal_item__content: content.field_text,
 } %}


### PR DESCRIPTION
## [YALB-1394: Bug: Accessibility (FE)- Empty heading being inserted when user does not fill in heading field](https://yaleits.atlassian.net/browse/YALB-1394)

This PR is linked to [component-library-twig PR #274](https://github.com/yalesites-org/component-library-twig/pull/274).

The original implementation disregarded the accordion_items in the component library and rendered them in atomic.  This was causing a missing h2 level when no accordion title was present.

To fix this, we preprocess the paragraph__accordion_item to inject a new attribute that will hold the heading_level that should be used, defaulting to 3.

### Description of work
- Add preprocessor for accordion item paragraph to inject the heading level based on the accordion's overall heading presence
- Use the new variable in the paragraph--accordion-item twig file, defaulting to 3 (the original hardcoded value)

### Functional testing steps:
- [ ] Add an accordion block to a page, ensuring an overall title is present
- [ ] After saving, view the HTML and verify that each item is showing as a `h3`
- [ ] Edit the block and remove the overall title of the accordion and save
- [ ] After saving, view the HTML and verify that each item is showing as a `h2`
