### PR TITLE
YALB-1442: WYSIWYG Creating and editing a table is visually and functionally broken

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -5,6 +5,7 @@ global:
       node_modules/@yalesites-org/component-library-twig/dist/style.css: {}
       components/_settings/_config.css: {}
       css/admin-theme.css: {}
+      css/ckeditor-overrides.css: {}
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/menu/menu-toggle/yds-menu-toggle.js: {}
     node_modules/@yalesites-org/component-library-twig/dist/js/00-tokens/layout/yds-layout.js: {}

--- a/css/ckeditor-overrides.css
+++ b/css/ckeditor-overrides.css
@@ -45,7 +45,7 @@
 /* Make the title similar to other titles on the admin side */
 .cke_dialog .cke_dialog_title {
   background: var(--mediterranean-blue) !important;
-  color: var(--wool) !important;
+  color: #fff !important;
 }
 
 /* Make the body color similar to the other displays on the admin side */

--- a/css/ckeditor-overrides.css
+++ b/css/ckeditor-overrides.css
@@ -38,3 +38,17 @@
 .cke_dialog tr:nth-child(even) {
   background-color: inherit !important;
 }
+
+.cke_dialog .cke_dialog_title {
+  background: var(--mediterranean-blue) !important;
+  color: var(--wool) !important;
+}
+
+.cke_dialog .cke_dialog_content_body {
+  background: var(--gin-bg-layer) !important;
+  color: var(--gin-color-text) !important;
+}
+
+.cke_dialog .cke_dialog_close_button {
+  background-image: url("data:image/svg+xml,%3Csvg%20width%3D%22100%22%20height%3D%22100%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cline%20x1%3D%220%22%20y1%3D%220%22%20x2%3D%22100%22%20y2%3D%22100%22%20stroke%3D%22white%22%20stroke-width%3D%223%22%2F%3E%0A%20%20%3Cline%20x1%3D%220%22%20y1%3D%22100%22%20x2%3D%22100%22%20y2%3D%220%22%20stroke%3D%22white%22%20stroke-width%3D%223%22%2F%3E%0A%3C%2Fsvg%3E") !important;
+}

--- a/css/ckeditor-overrides.css
+++ b/css/ckeditor-overrides.css
@@ -20,7 +20,7 @@
   background-color: var(--gin-color-primary) !important;
 }
 
-.cke_dialog input {
+.cke_dialog input, .cke_dialog select {
   border-radius: 6px !important;
 }
 
@@ -33,4 +33,8 @@
   background-position: 100% 50% !important;
   background-size: 2.75em .5625em !important;
   line-height: 1.5em !important;
+}
+
+.cke_dialog tr:nth-child(even) {
+  background-color: inherit !important;
 }

--- a/css/ckeditor-overrides.css
+++ b/css/ckeditor-overrides.css
@@ -1,0 +1,6 @@
+/* Fix CKEditor modal table dialog from displaying borders where it should not */
+/* .cke_dialog_body tbody tr:last-child td, td.cke_dialog_ui_vbox_child, td.cke_dialog_contents_body { */
+.cke_dialog td {
+  border-bottom: 0 !important;
+}
+

--- a/css/ckeditor-overrides.css
+++ b/css/ckeditor-overrides.css
@@ -1,6 +1,36 @@
+@import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&display=swap");
+
 /* Fix CKEditor modal table dialog from displaying borders where it should not */
 /* .cke_dialog_body tbody tr:last-child td, td.cke_dialog_ui_vbox_child, td.cke_dialog_contents_body { */
 .cke_dialog td {
   border-bottom: 0 !important;
 }
 
+.cke_dialog * {
+  font-family: var(--gin-font) !important;
+}
+
+/* Generic button overrides */
+.cke_dialog .cke_dialog_ui_button {
+  border-radius: 2.5rem !important;
+}
+
+/* Restyle Ok button */
+.cke_dialog .cke_dialog_ui_button_ok {
+  background-color: var(--gin-color-primary) !important;
+}
+
+.cke_dialog input {
+  border-radius: 6px !important;
+}
+
+.cke_dialog select.cke_dialog_ui_input_select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: calc(2.5em - 1px) !important;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14 9'%3e%3cpath fill='none' stroke-width='1.5' d='M1 1l6 6 6-6' stroke='%23545560'/%3e%3c/svg%3e") !important;
+  background-repeat: no-repeat !important;
+  background-position: 100% 50% !important;
+  background-size: 2.75em .5625em !important;
+  line-height: 1.5em !important;
+}

--- a/css/ckeditor-overrides.css
+++ b/css/ckeditor-overrides.css
@@ -1,11 +1,11 @@
 @import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&display=swap");
 
 /* Fix CKEditor modal table dialog from displaying borders where it should not */
-/* .cke_dialog_body tbody tr:last-child td, td.cke_dialog_ui_vbox_child, td.cke_dialog_contents_body { */
 .cke_dialog td {
   border-bottom: 0 !important;
 }
 
+/* Set font over all of the dialog */
 .cke_dialog * {
   font-family: var(--gin-font) !important;
 }
@@ -20,10 +20,12 @@
   background-color: var(--gin-color-primary) !important;
 }
 
+/* Round inputs */
 .cke_dialog input, .cke_dialog select {
   border-radius: 6px !important;
 }
 
+/* Mimic selects in other areas, like the divider */
 .cke_dialog select.cke_dialog_ui_input_select {
   appearance: none;
   -webkit-appearance: none;
@@ -35,20 +37,24 @@
   line-height: 1.5em !important;
 }
 
+/* Remove the alternating background color */
 .cke_dialog tr:nth-child(even) {
   background-color: inherit !important;
 }
 
+/* Make the title similar to other titles on the admin side */
 .cke_dialog .cke_dialog_title {
   background: var(--mediterranean-blue) !important;
   color: var(--wool) !important;
 }
 
+/* Make the body color similar to the other displays on the admin side */
 .cke_dialog .cke_dialog_content_body {
   background: var(--gin-bg-layer) !important;
   color: var(--gin-color-text) !important;
 }
 
+/* Remake the X button so we can color it white--it was a png before */
 .cke_dialog .cke_dialog_close_button {
   background-image: url("data:image/svg+xml,%3Csvg%20width%3D%22100%22%20height%3D%22100%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cline%20x1%3D%220%22%20y1%3D%220%22%20x2%3D%22100%22%20y2%3D%22100%22%20stroke%3D%22white%22%20stroke-width%3D%223%22%2F%3E%0A%20%20%3Cline%20x1%3D%220%22%20y1%3D%22100%22%20x2%3D%22100%22%20y2%3D%220%22%20stroke%3D%22white%22%20stroke-width%3D%223%22%2F%3E%0A%3C%2Fsvg%3E") !important;
 }


### PR DESCRIPTION
## [YALB-1442: WYSIWYG Creating and editing a table is visually and functionally broken](https://yaleits.atlassian.net/browse/YALB-1442)

The modal not working is addressed in [YALB-956](https://yaleits.atlassian.net/browse/YALB-956)

### Description of work
- Add ckeditor-overrides.css file
- Add styling to `.cke_dialog` elements that are more in line with our theme
  - No ugly black border lines all over the place
  - Attempt to style inputs and selects to match our style in other places
  - Style buttons to look like our theme
  - Style header to look like our theme
  - Recreate X to be a SVG over a black PNG

### Functional testing steps:
- [ ] Create a new page
- [ ] Add a new block: Text
- [ ] In the CKEditor window, click the "table" icon
- [ ] Verify that the modal that shows looks usable and conforms to our design standards


[YALB-956]: https://yaleits.atlassian.net/browse/YALB-956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ