### PR TITLE
YALB-1388 - Feedback: Embed Block | YALB-1390 - Remove transparency from banner overlay | YALB-1417 - Bug: Block picker in Posts and Events only have 2 columns compared to 3 on Pages | YALB-1463 - Bug: Content Spotlight Border severely impacts use/placement of Block | YALB-858 - Feedback: Site Name looks too small on mobile

### DIFF
--- a/templates/block/layout-builder/block--inline-block--embed.html.twig
+++ b/templates/block/layout-builder/block--inline-block--embed.html.twig
@@ -2,7 +2,15 @@
 
 {% block content %}
 
-  {% embed "@molecules/embed/yds-embed.twig" %}
+  {% if parentNode == 'post' or parentNode == 'event' %}
+    {% set embed__width = "content" %}
+  {% else %}
+    {% set embed__width = "site" %}
+  {% endif %}
+
+  {% embed "@molecules/embed/yds-embed.twig" with {
+    embed__width: embed__width,
+  }%}
 
     {% block embed__block %}
       {{ content }}


### PR DESCRIPTION
## [YALB-1388 - Feedback: Embed Block](https://yaleits.atlassian.net/browse/YALB-1388) | [YALB-1390 - Remove transparency from banner overlay](https://yaleits.atlassian.net/browse/YALB-1390) |  [YALB-1417 - Bug: Block picker in Posts and Events only have 2 columns compared to 3 on Pages](https://yaleits.atlassian.net/browse/YALB-1417) | [YALB-1463 - Bug: Content Spotlight Border severely impacts use/placement of Block](https://yaleits.atlassian.net/browse/YALB-1463) | [YALB-858 - Feedback: Site Name looks too small on mobile](https://yaleits.atlassian.net/browse/YALB-858)

### Test here: https://github.com/yalesites-org/component-library-twig/pull/276

### Description
- [ ] Update layout builder template for `embed` content to include `embed__width` to make the width more narrow on `event` and `post` content