### PR TITLE
Yalb 1501 alt

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -350,10 +350,23 @@ body.gin--horizontal-toolbar {
 
 .gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab .toolbar-tray a:hover,
 .gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab .toolbar-tray a:active,
-table tr:hover,
-table .draggable-table.tabledrag-disabled tr:hover {
+#layout-builder-components-table table tr:hover,
+.ui-widget-content #layout-builder-components-table table tr:hover a,
+#layout-builder-components-table table tr td.layout-builder-components-table__block-label:hover,
+#layout-builder-components-table table .draggable-table.tabledrag-disabled tr:hover,
+#layout-builder-components-table table .draggable-table.tabledrag-disabled tr:hover td,
+#layout-builder-components-table table .draggable-table.tabledrag-disabled tr a:hover  {
   color: var(--wool);
   background: var(--dark-theme-gray);
+}
+
+.cke_dialog_contents tr:hover,
+.cke_dialog_contents_body table tr:hover {
+  background: var(--wool);
+}
+
+.cke_dialog_footer_buttons a.cke_dialog_ui_button {
+  color: var(--dark-theme-gray);
 }
 
 #block-atomic-local-tasks ul:not(.contextual-links) {
@@ -515,10 +528,6 @@ table .draggable-table.tabledrag-disabled tr:hover {
   background-color: var(--dark-theme-gray-lightest);
 }
 
-/* yalb-1296 - table tr hover in text component */
-.text table tr:hover {
-  color: var(--color-text);
-}
 
 /* yalb-1251 - AX: pencil icon difficulty editing blocks */
 /* change the contextual pencil icon to the left-hand side of each component

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -24,6 +24,7 @@
 
   --dark-gin-icon-color: var(--wool);
   --gin-color-text-light: var(--wool);
+  --gin-color-text-light: var(--wool);
 
   --gin-font: "DM Mono", monospace;
   --gin-font-size-h1: 1.75rem;
@@ -42,14 +43,14 @@
 }
 
 :root [data-gin-accent=light_blue] {
+  --gin-color-primary: var(--robin-egg);
   --gin-color-primary-rgb: 217, 241, 243;
   --gin-color-primary-active: var(--wool);
   --gin-color-secondary: var(--mediterranean-blue);
-  --gin-color-text-light: var(--wool);
   --gin-icon-color: var(--dark-gin-icon-color);
   --gin-bg-item-hover: var(--dark-theme-gray-hover);
   --gin-bg-header: var(--dark-theme-gray);
-  --gin-color-primary-hover: var(--dark-primary-link-hover);
+  --gin-color-primary-hover: var(--dark-primary-link-hover) !important;
   --gin-color-primary-light: var(--gin-bg-item-hover) !important;
   --gin-border-color-layer: var(--light-gray);
   --gin-bg-layer: var(--dark-theme-gray);
@@ -76,314 +77,23 @@
 }
 
 
-/* media modal */
-
-.glb-view-header a.views-display-link.views-display-link-widget_table {
-  color: var(--wool) !important;
+.gin--dark-mode .gin-secondary-toolbar--frontend {
+  background: rgba(var(--dark-theme-gray-rgb), 1);
 }
 
-.glb-view-header .views-display-link.views-display-link-widget.is-active {
-  color: var(--wool) !important;
+/* // toolbar overrides */
+.gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab .toolbar-tray a:hover, 
+.gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab .toolbar-tray a:active {
+  background-color: var(--darkest-gray);
 }
 
-.glb-view-header .views-display-link::before {
-  background-color: var(--wool) !important;
-}
-
-#views-exposed-form-media-library-widget .glb-form-item__label {
-  color: var(--wool) !important;
-}
-
-.glb-form-checkbox:checked {
-  background-color: var(--dark-theme-gray) !important;
-}
-
-.media-library-selected-count {
-  color: var(--dark-theme-gray) !important;
-}
-
-.glb-pager .pager__link {
-  color: var(--mediterranean-blue) !important;
-}
-
-.glb-pager .pager__link:hover,
-.glb-pager .pager__link:focus {
-  background: var(--dark-theme-gray-lightest) !important;
-  border-color: var(--dark-theme-gray) !important;
-}
-
-.glb-pager .pager__item .pager__link--action-link::before,
-.glb-pager .pager__item .pager__link--action-link::after {
-  background: var(--dark-theme-gray) !important;
-}
-
-.glb-pager .pager__item .pager__link--action-link:hover::before,
-.glb-pager .pager__item .pager__link--action-link:focus::after,
-.glb-pager .pager__item .pager__link:hover::after,
-.glb-pager .pager__item .pager__link:focus::after {
-  background: var(--dark-theme-gray) !important;
-}
-
-.glb-pager .pager__link.is-active,
-.glb-pager .pager__item--current {
-  color: var(--dark-theme-gray) !important;
-}
-
-/* linkit ui autocomplete */
-.ui-autocomplete .ui-menu-item-wrapper.ui-state-active {
-  background-color: var(--dark-theme-gray-lightest);
-}
-
-/* Off-canvas overrides */
-#drupal-off-canvas {
-  background-color: var(--wool);
-  color: var(--darkest-gray);
-}
-
-.ui-dialog-content,
-.ui-dialog-off-canvas .ui-dialog-titlebar {
-  background: var(--wool) !important;
-}
-
-#layout-builder-modal {
-  background: var(--wool) !important;
-}
-
-.ui-dialog-off-canvas #drupal-off-canvas {
-  padding-inline: var(--size-spacing-5) var(--size-spacing-8);
-}
-
-#drupal-off-canvas form,
-#drupal-off-canvas label {
-  color: var(--darkest-gray);
-}
-
-.ui-widget-content a {
-  color: var(--dark-theme-gray) !important;
-}
-
-.ui-menu-item-wrapper:hover {
-  background-color: var(--dark-theme-gray-lightest);
-}
-
-.ui-widget.ui-dialog.ui-dialog-off-canvas .ui-dialog-titlebar {
-  display: flex;
-  align-items: center;
-  border-color: var(--dark-theme-gray);
-}
-
-.ui-widget.ui-dialog.ui-dialog-off-canvas .ui-dialog-titlebar {
-  background-color: var(--dark-theme-gray-hover) !important;
-}
-
-.glb-claro-details[open]>.glb-claro-details__summary {
-  color: var(--gin-color-primary) !important;
-  background-color: var(--dark-theme-gray-hover) !important;
-}
-
-.glb-claro-details[open]>.glb-claro-details__summary::before {
-  background: var(--gin-color-primary) !important;
-}
-
-.glb-claro-details__summary:hover::before {
-  background: var(--gin-color-primary) !important;
-}
-
-.glb-form-item__description,
-.glb-fieldset__description {
-  color: var(--dark-theme-gray) !important;
-}
-
-.glb-form-wrapper .cke .cke_top,
-.glb-form-wrapper .cke .cke_bottom {
-  background: var(--dark-theme-gray-lightest) !important;
-}
-
-.glb-form-wrapper .cke a.cke_path_item,
-.glb-form-wrapper .cke span.cke_path_empty {
-  color: var(--dark-theme-gray) !important;
-}
-
-.glb-form-wrapper .cke a.cke_button_off:hover,
-.glb-form-wrapper .cke a.cke_button_off:focus,
-.glb-form-wrapper .cke a.cke_button_off:active {
-  background: var(--wool) !important;
-}
-
-:not(.glb-form-checkboxes):not(td):not(.media-library-item__click-to-select-checkbox):not(.field-content)>.glb-form-type--checkbox label {
-  color: var(--wool) !important;
-}
-
-[dir="ltr"] .gin-secondary-toolbar .toolbar-secondary .toolbar-bar div:last-child .toolbar-tray {
-  border-radius: 0 0 var(--gin-border-l) var(--gin-border-l);
-}
-
-.ui-dialog.ui-dialog-off-canvas .ui-dialog-title,
-#drupal-off-canvas form,
-#drupal-off-canvas span,
-#drupal-off-canvas label,
-#drupal-off-canvas input[type="submit"].button {
-  font-family: var(--gin-font) !important;
-}
-
-#drupal-off-canvas input[type="submit"].button {
-  box-sizing: border-box;
-  padding: var(--size-spacing-5);
-  background-color: var(--custom-button-color) !important;
-  color: var(--custom-button-color-text) !important;
-}
-
-.ui-widget.ui-dialog.ui-dialog-off-canvas #drupal-off-canvas .button--primary[type="submit"]:hover,
-.ui-widget.ui-dialog.ui-dialog-off-canvas #drupal-off-canvas .button--primary[type="submit"]:focus {
-  background-color: var(--dark-theme-gray-hover) !important;
-  color: var(--wool) !important;
-}
-
-
-/* Modal */
-.ui-widget-overlay {
-  background: var(--gin-color-primary) !important;
-}
-
-.ui-dialog-titlebar {
-  display: flex;
-  align-items: center;
-  background: var(--gin-color-primary-active) !important;
-}
-
-[data-gin-accent="light_blue"] .ws-lb-link__label {
-  background: var(--wool) !important;
-}
-
-[data-gin-accent="light_blue"] .ui-dialog-titlebar .ui-dialog-title {
-  color: var(--wool) !important;
-}
-
-[data-gin-accent="light_blue"] .ui-dialog .ui-dialog-titlebar-close .ui-icon-closethick {
-  background: var(--wool) !important;
-}
-
-.gin-secondary-toolbar--frontend {
-  position: fixed;
-  background-color: var(--gin-bg-layer);
-  width: 100%;
-  top: calc(var(--gin-toolbar-secondary-height) - 7px) !important;
-}
-
-.gin-breadcrumb__item:first-of-type .gin-breadcrumb__link:hover::before {
-  background-color: var(--dark-primary-link-hover) !important;
-}
-
-.gin-breadcrumb__link:hover {
-  text-decoration: underline;
-}
-
-.gin-breadcrumb__link:hover,
-.gin-breadcrumb__link:hover em {
-  color: var(--dark-primary-link-hover) !important;
-}
-
-.gin-breadcrumb__item:first-of-type .gin-breadcrumb__link:hover::before {
-  background-color: var(--dark-primary-link-hover) !important;
-}
-
-body.gin--horizontal-toolbar {
-  padding-top: calc(var(--gin-toolbar-y-offset) + var(--gin-toolbar-secondary-height)) !important;
-}
-
-[data-gin-accent=light_blue] .ui-widget-overlay {
-  background: var(--peacock-green) !important;
-}
-
-[data-gin-accent=light_blue] .ui-dialog-titlebar {
-  background: var(--dark-theme-gray) !important;
-}
-
-.toolbar-menu-administration>.toolbar-menu>.menu-item:hover>.toolbar-icon::before,
-.toolbar-menu-administration>.toolbar-menu>.menu-item:hover>.toolbar-box>a.toolbar-icon::before,
-.toolbar-menu-administration>.toolbar-menu>.menu-item>.toolbar-icon:focus::before,
-.toolbar-menu-administration>.toolbar-menu>.menu-item.menu-item--active-trail>.toolbar-icon::before,
-.toolbar-menu-administration>.toolbar-menu>.menu-item.menu-item--active-trail:hover>.toolbar-icon::before,
-.toolbar-menu-administration>.toolbar-menu>.menu-item.menu-item--active-trail>.toolbar-box>a.toolbar-icon::before {
-  z-index: 1;
-}
-
-.toolbar-menu-administration>.toolbar-menu>.menu-item.menu-item--active-trail>.toolbar-icon::after,
-.toolbar-menu-administration>.toolbar-menu>.menu-item.menu-item--active-trail>.toolbar-box>a.toolbar-icon::after,
-.toolbar-menu-administration>.toolbar-menu>.menu-item>.toolbar-icon.is-active::after {
-  background-color: var(--gin-color-primary-light) !important;
-}
-
-.gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab:hover .trigger::before,
-.gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab:focus .trigger::before {
-  background-color: var(--wool) !important;
-}
-
-.gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab>.toolbar-icon-edit.toolbar-item:hover .gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab>.toolbar-icon-edit.toolbar-item:focus {
+/* // override toolbar drop-down arrow color */
+.gin--dark-mode .toolbar-tray-horizontal ul li.menu-item--expanded ul li.menu-item--expanded::before {
   background-color: var(--wool);
 }
 
-.gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab:hover .trigger {
-  color: var(--wool) !important;
-}
 
-.is-horizontal .tabs__link:hover,
-.is-horizontal .tabs__link:focus,
-.horizontal-tabs ul.horizontal-tabs-list li.horizontal-tab-button a:hover,
-.horizontal-tabs ul.horizontal-tabs-list li.horizontal-tab-button a:focus {
-  background: var(--gin-color-primary-light);
-}
-
-.form-element {
-  border-radius: 0.625rem !important;
-}
-
-.block-system>.views-form [data-drupal-selector*="edit-header"],
-.view-content .views-form [data-drupal-selector*="edit-header"] {
-  background-color: transparent !important;
-}
-
-.admin-item .admin-item__link:hover,
-.admin-item .admin-item__link:focus {
-  background: rgba(var(--gin-color-primary-rgb), 0.15) !important;
-}
-
-.gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab .toolbar-tray a:hover,
-.gin-secondary-toolbar .toolbar-secondary .toolbar-bar .toolbar-tab .toolbar-tray a:active,
-#layout-builder-components-table table tr:hover,
-.ui-widget-content #layout-builder-components-table table tr:hover a,
-#layout-builder-components-table table tr td.layout-builder-components-table__block-label:hover,
-#layout-builder-components-table table .draggable-table.tabledrag-disabled tr:hover,
-#layout-builder-components-table table .draggable-table.tabledrag-disabled tr:hover td,
-#layout-builder-components-table table .draggable-table.tabledrag-disabled tr a:hover  {
-  color: var(--wool);
-  background: var(--dark-theme-gray);
-}
-
-.cke_dialog_contents tr:hover,
-.cke_dialog_contents_body table tr:hover {
-  background: var(--wool);
-}
-
-.cke_dialog_footer_buttons a.cke_dialog_ui_button {
-  color: var(--dark-theme-gray);
-}
-
-#block-atomic-local-tasks ul:not(.contextual-links) {
-  list-style: none;
-  display: flex;
-}
-
-/* Layout styles */
-
-/* override button font  */
-.glb-sidebar .form-actions,
-.glb-button,
-.layout-builder__link,
-.glb-form-wrapper,
-.glb-sidebar__content {
-  font-family: var(--gin-font) !important;
-}
+/* // Layout-builder  */
 
 .glb-button,
 .inline-block-create-button,
@@ -396,7 +106,7 @@ body.gin--horizontal-toolbar {
 .glb-action-link--icon-trash.glb-action-link,
 .meta-sidebar__trigger.is-active,
 .meta-sidebar__close.is-active {
-  background-color: var(--gin-color-primary-light) !important;
+  background-color: var(--darkest-gray) !important;
 }
 
 .glb-button,
@@ -426,44 +136,47 @@ body.gin--horizontal-toolbar {
   border-color: var(--dark-theme-gray-hover) !important;
 }
 
-.glb-button:hover {
-  color: var(--dark-theme-gray) !important;
+.glb-button:active, 
+.inline-block-create-button:active, 
+.layout-builder__link--add:active, 
+.glb-button:focus, 
+.inline-block-create-button:focus, 
+.layout-builder__link--add:focus, 
+.glb-button:not(:focus):active, 
+.inline-block-create-button:not(:focus):active, 
+.layout-builder__link--add:not(:focus):active, 
+.glb-button:not(:focus):focus, 
+.inline-block-create-button:not(:focus):focus, 
+.layout-builder__link--add:not(:focus):focus, 
+.form-actions .glb-button:active, 
+.form-actions .inline-block-create-button:active, 
+.form-actions .layout-builder__link--add:active, 
+.form-actions .glb-button:focus, 
+.form-actions .inline-block-create-button:focus, 
+.form-actions .layout-builder__link--add:focus, 
+.glb-action-link--icon-trash.glb-action-link:active, 
+.glb-action-link--icon-trash.glb-action-link:focus {
+  background-color: var(--robin-egg) !important;
 }
 
-.glb-button:not(:focus) {
-  filter: none !important;
-  box-shadow: none !important;
+
+.layout-builder__section:hover .layout-builder__link--add-section-to-library,
+.layout-builder__section:hover .layout-builder__link--remove {
+  background-color: var(--dark-theme-gray-hover) !important;
 }
 
-.gin-secondary-toolbar__layout-container *:focus {
-  box-shadow: 0 0 0 3px #d4d4d4 !important;
-}
-
-.glb-table .tabledrag-handle::after {
+.layout-builder__section:hover .layout-builder__link--configure {
+  color: var(--wool) !important;
   background-color: var(--dark-theme-gray) !important;
 }
 
-.glb-table tr:hover,
-.glb-table .draggable-table.tabledrag-disabled tr:hover {
-  background: var(--dark-theme-gray-lightest);
-}
-
-
-.meta-sidebar__trigger,
-.meta-sidebar__close {
-  background-color: var(--gin-color-primary-light);
-}
-
-.meta-sidebar__trigger::before,
-.meta-sidebar__close::before {
-  background-color: var(--gin-color-primary);
-}
-
-.glb-button,
-.inline-block-create-button,
-.layout-builder__link--add,
-.layout-builder__link {
-  font-family: var(--gin-font);
+/* Sections on nodes */
+.layout-builder .layout-builder__add-section {
+  position: relative;
+  background-color: hsl(180, 7%, 90%);
+  padding: 1rem 2rem;
+  margin: 2rem 1rem;
+  max-width: calc(100% - 2rem);
 }
 
 .layout-builder__link--configure {
@@ -475,125 +188,33 @@ body.gin--horizontal-toolbar {
   background-color: var(--dark-theme-gray-hover);
 }
 
+.layout-builder__section:not(.gin-lb--disable-section-focus)::after {
+  border: 0.35rem solid  hsl(180, 7%, 75%) !important;
+  position: absolute;
+  content: '';
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+}
+
 .layout-builder__section:not(.gin-lb--disable-section-focus):hover::after {
-  border: 0.25rem solid var(--dark-theme-gray-hover) !important;
-}
-
-#media-library-messages .messages {
-  border-radius: var(--gin-border-l);
-  padding: 1rem;
-}
-
-#media-library-messages .messages--error {
-  color: var(--gin-color-danger-light);
-  background-color: var(--gin-bg-danger);
-}
-
-#media-library-messages .messages--warning {
-  color: var(--gin-color-warning-light);
-  background-color: var(--gin-bg-warning);
+  border: 0.35rem solid  hsl(180, 7%, 20%) !important;
 }
 
 .layout-builder__section {
-  margin-inline-start: 0.5rem;
-  margin-inline-end: 0.5rem;
+  margin: 2rem 1rem;
 }
 
-.layout-builder__section:hover .layout-builder__link--add-section-to-library {
-  background-color: var(--dark-theme-gray-hover) !important;
+.layout-builder__section .js-layout-builder-region {
+  padding: 1rem;
 }
 
-.layout-builder__section:hover .layout-builder__link--remove {
-  background-color: var(--dark-theme-gray-hover) !important;
-}
-
-.layout-builder__section:hover .layout-builder__link--configure {
-  background-color: var(--dark-theme-gray-hover) !important;
-  color: var(--gin-color-primary) !important;
-}
-
-/* yalb-1261 - fix hover color on table */
-
-.layout-builder-components-table__block-label:hover {
-  color: var(--dark-theme-gray-hover);
-  text-decoration: underline;
-}
-
-.layout-builder-components-table th:hover {
-  color: var(--dark-theme-gray-hover);
-}
-
-.layout-builder-components-table tr:hover {
+/* Layout builder modal */
+.ws-lb-link__label {
   color: var(--dark-theme-gray);
-  background-color: var(--dark-theme-gray-lightest);
 }
 
-
-/* yalb-1251 - AX: pencil icon difficulty editing blocks */
-/* change the contextual pencil icon to the left-hand side of each component
-// instead of the right
-*/
-.layout-builder-block.contextual-region .contextual {
-  display: flex;
-  flex-direction: column;
-  top: 1rem;
-  left: 2vw;
-  right: auto;
-  width: auto;
+.gin--dark-mode .glb-form-element {
+  background-color: var(--dark-theme-gray) !important;
 }
-
-@media only screen and (min-width: 2200px) {
-  .layout-builder-block.contextual-region .contextual {
-    left: 15vw;
-  }
-}
-
-@media only screen and (min-width: 2500px) {
-  .layout-builder-block.contextual-region .contextual {
-    left: 20vw;
-  }
-}
-
-.layout-builder-block.contextual-region .contextual .contextual-links {
-  left: 0;
-  right: 0;
-  float: unset;
-}
-
-/* increase the size of the clickable/hoverable area */
-.layout-builder-block.contextual-region .contextual .trigger {
-  width: 50px !important;
-  height: 50px !important;
-}
-
-/* increase the size of the icon itself */
-.layout-builder-block.contextual-region .contextual .trigger::before {
-  width: 1.2rem;
-  height: 1.2rem;
-  mask-size: 1.2rem;
-  -webkit-mask-size: 1.2rem;
-}
-
-/* add min-height so that smaller (in height) components are more easily
-// able to be interacted with - e.g. `divider`
-*/
-.layout-builder-block {
-  min-height: 6rem;
-}
-
-/* increase padding around the divider when in layout-builder, to make the
-// divider more visible
-*/
-.layout-builder-block .divider__wrapper {
-  display: flex;
-  align-items: center;
-  padding-inline: 2rem;
-}
-
-
-/* Blocks - accordion block, button block */
-.field--name-field-accordion-items th h4,
-.field--name-field-button-link th h4 {
-  color: var(--wool) !important;
-}
-

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -8,20 +8,11 @@
   --darkest-gray: #1f1f1f;
   --dark-theme-gray-rgb: 78, 89, 89;
   --dark-theme-gray: #4E5959;
-  --dark-theme-gray-selected: #edfbfb;
-  --dark-theme-gray-lightest: #d0e0e0;
-  --dark-theme-gray-lightest-rgb: 208, 224, 224;
-  --dark-theme-gray-light: #606A6A;
   --dark-theme-gray-hover: #353d3d;
   --dark-primary-link: var(--wool);
   --dark-primary-link-hover: #ffffff;
   --dark-theme-gray-text-light: var(--wool);
   --dark-theme-gray-text-dark: var(--dark-theme-gray);
-  --custom-button-color: var(--robin-egg);
-  --custom-button-color-hover: var(--wool);
-  --custom-button-color-text: var(--dark-theme-gray-hover);
-  --custom-button-color-text-hover: var(--dark-theme-gray-hover);
-
   --dark-gin-icon-color: var(--wool);
   --gin-color-text-light: var(--wool);
   --gin-color-text-light: var(--wool);
@@ -54,6 +45,7 @@
   --gin-color-primary-light: var(--gin-bg-item-hover) !important;
   --gin-border-color-layer: var(--light-gray);
   --gin-bg-layer: var(--dark-theme-gray);
+  --gin-bg-input: var(--darkest-gray) !important;
   --gin-dark-gray: var(--darkest-gray);
   --colorGinText: var(--darkest-gray);
   --gin-border-color-table-header: var(--darkest-gray);
@@ -76,7 +68,7 @@
   font-weight: 600;
 }
 
-
+.gin--dark-mode .gin-secondary-toolbar,
 .gin--dark-mode .gin-secondary-toolbar--frontend {
   background: rgba(var(--dark-theme-gray-rgb), 1);
 }

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -44,6 +44,7 @@
   --gin-color-primary-light: var(--gin-bg-item-hover) !important;
   --gin-border-color-layer: var(--light-gray);
 
+  --gin-bg-app: var(--darkest-gray);
   --gin-bg-layer: var(--dark-theme-gray);
   --gin-bg-input: var(--darkest-gray) !important;
   --gin-dark-gray: var(--darkest-gray);

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -11,13 +11,10 @@
   --dark-theme-gray-hover: #353d3d;
   --dark-primary-link: var(--wool);
   --dark-primary-link-hover: #ffffff;
-  --dark-theme-gray-text-light: var(--wool);
-  --dark-theme-gray-text-dark: var(--dark-theme-gray);
   --dark-gin-icon-color: var(--wool);
   --gin-color-text-light: var(--wool);
-  --gin-color-text-light: var(--wool);
 
-  --gin-font: "DM Mono", monospace;
+  --gin-font: Mallory, sans-serif;
   --gin-font-size-h1: 1.75rem;
   --gin-font-size-h2: 1.5rem;
   --gin-font-size-h3: 1.25rem;
@@ -36,31 +33,29 @@
 :root [data-gin-accent=light_blue] {
   --gin-color-primary: var(--robin-egg);
   --gin-color-primary-rgb: 217, 241, 243;
-  --gin-color-primary-active: var(--wool);
+  --gin-color-primary-active: var(--wool) !important;
   --gin-color-secondary: var(--mediterranean-blue);
   --gin-icon-color: var(--dark-gin-icon-color);
   --gin-bg-item-hover: var(--dark-theme-gray-hover);
   --gin-bg-header: var(--dark-theme-gray);
-  --gin-color-primary-hover: var(--dark-primary-link-hover) !important;
+  --gin-color-text: var(--wool);
+  --gin-color-text-light: var(--wool);
+  --gin-color-primary-hover: var(--wool) !important;
   --gin-color-primary-light: var(--gin-bg-item-hover) !important;
   --gin-border-color-layer: var(--light-gray);
+
   --gin-bg-layer: var(--dark-theme-gray);
   --gin-bg-input: var(--darkest-gray) !important;
   --gin-dark-gray: var(--darkest-gray);
   --colorGinText: var(--darkest-gray);
   --gin-border-color-table-header: var(--darkest-gray);
   --gin-bg-layer3: var(--dark-theme-gray-hover);
-  --gin-color-title: var(--dark-theme-gray-text);
   --gin-color-dark-text: var(--wool);
-  --gin-color-title: var(--dark-theme-gray);
+  --gin-color-title: var(--wool);
   --gin-color-button-text: var(--dark-theme-gray);
   --gin-color-button-text-hover: var(--dark-theme-gray-hover);
 }
 
-[data-gin-accent=light_blue] {
-  --gin-bg-app: #fcfefe;
-  --gin-bg-app-rgb: rgb(252, 254, 254);
-}
 
 /* affect admin paths only */
 :root .path-admin h1,
@@ -87,6 +82,7 @@
 
 /* // Layout-builder  */
 
+/* Buttons */
 .glb-button,
 .inline-block-create-button,
 .layout-builder__link--add,
@@ -209,4 +205,29 @@
 
 .gin--dark-mode .glb-form-element {
   background-color: var(--dark-theme-gray) !important;
+}
+
+.ui-dialog-titlebar {
+  background: var(--darkest-gray);
+}
+
+
+/* chosen overrides */
+.gin--dark-mode .chosen-container .chosen-results li.highlighted {
+  background-color: var(--gin-color-primary);
+  color: var(--darkest-gray);
+}
+
+.gin--dark-mode .chosen-container-single .chosen-single span {
+  color: var(--wool);
+}
+
+.gin--dark-mode .chosen-search-input,
+.gin--dark-mode .chosen-search-input::placeholder {
+  color: var(--dark-theme-gray) !important;
+}
+
+/* search input placeholder opacity */
+input[type="search"]::placeholder {
+  opacity: 1;
 }


### PR DESCRIPTION
## [YALB-1501: Bug: Missing admin styles](https://yaleits.atlassian.net/browse/YALB-1501)

### Description of work
- Changes the theme configuration to use the `dark` variation (dark-mode). 
- **This change results in significantly less overrides and overall would help to sustain and stabilize our customizations**.
- The big CSS variable which factors into the admin page background colors is `var(--gin-bg-layer)` which is used for the toolbar and it is used as the main content area background-color ( specifically on these, ```.gin-layer-wrapper, .block-system-main-block > form, .views-exposed-form.views-exposed-form, .views-edit-view, .views-preview-wrapper, #views-entity-list, .module-filter-update-status-form .table-filter, .admin.my-workbench```) 
  - Because the `--gin-bg-layer` (`--dark-theme-gray: #4E5959;`) is a dark color, using the `gin--dark-mode` sets all content within to use `var(--gin-color-text)` which does not need to change from `(--wool)`. 
  - I did override the background color for the above noted selectors to use an even darker background color (` --darkest-gray: #1f1f1f;` ) to avoid insufficient contrast when I checked Wave's contrast checker. 
  - This allows us to not override specific text elements on top of a lighter background color, as in the previous design and approach in the initial admin darker theme redesign. 
- Refines CSS variables, removing some we no longer need.
