### PR TITLE
YALB 1511 - Theming Primary Navigation Headings

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -54,6 +54,7 @@ fontawesome:
       node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/fontawesome.css: {}
       node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/regular.css: {}
       node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/solid.css: {}
+
 layout-builder:
   css:
     theme:

--- a/templates/navigation/menu--extras--main.html.twig
+++ b/templates/navigation/menu--extras--main.html.twig
@@ -1,3 +1,4 @@
+{# Note: After enabling menu_item_extras module, this file was renamed from menu--main.html.twig #}
 {{ attach_library('atomic/primary-nav') }}
 {{ attach_library('atomic/fontawesome')}}
 

--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -1,4 +1,5 @@
 {{ attach_library('atomic/primary-nav') }}
+{{ attach_library('atomic/fontawesome')}}
 
 {% include "@organisms/menu/primary-nav/yds-primary-nav.twig"  with {
   menu__variation: getThemeSetting('nav_type'),


### PR DESCRIPTION
## [YALB-1511 - Mega Menu: Present Level One links as Headings - FE](https://yaleits.atlassian.net/browse/YALB-1511)

### Description of work
- Attaches the fontawesome library to the main-menu so it is available

### Functional testing steps:
- [ ] Verify when testing the main branch: 
- [ ] Verify the angle-right icon loads for the menu headings
