### PR TITLE
fix(yalb-1416): add ternary check for heading value

### DIFF
--- a/templates/block/layout-builder/block--inline-block--cta-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--cta-banner.html.twig
@@ -4,6 +4,7 @@
 
   {% embed "@molecules/banner/action/yds-action-banner.twig" with {
     banner__heading: content.field_heading,
+    banner__heading__level: content.field_heading_level.0['#markup'],
     banner__snippet: content.field_text,
     banner__link__content: content.field_link.0['#title'],
     banner__link__url: content.field_link.0['#url_title'],

--- a/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
+++ b/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
@@ -6,6 +6,7 @@
 
   {% embed "@molecules/banner/grand-hero/yds-grand-hero.twig" with {
     grand_hero__heading: content.field_heading,
+    grand_hero__heading__level: content.field_heading_level.0['#markup'],
     grand_hero__snippet: content.field_text,
     grand_hero__link__content: content.field_link.0['#title'],
     grand_hero__link__url: content.field_link.0['#url_title'],

--- a/templates/block/layout-builder/block--inline-block--view.html.twig
+++ b/templates/block/layout-builder/block--inline-block--view.html.twig
@@ -17,11 +17,11 @@
         class: bem(view__base_class, view__modifiers),
       } %}
   {% endif %}
-
+  
   <div {{ add_attributes(view__attibutes) }}>
     {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
       component_wrapper__width: component_wrapper__width|default('site'),
-      component_wrapper__label: content.field_heading,
+      component_wrapper__label: content.field_heading.0 ? content.field_heading : '',
       }%}
       {% block component_wrapper_inner %}
         {% if content.field_view_params %}


### PR DESCRIPTION
## [YALB-1416: Bug: Empty Headings in HTML](https://yaleits.atlassian.net/browse/YALB-1416) |  [YALB-1215: Dials: Banner heading levels](https://yaleits.atlassian.net/browse/YALB-1215)


### Description of work
- YALB-1416 - Add check if heading value is present, if so render it, otherwise don't
- YALB-1215 - Wire `heading__level` from each `banner` component to Drupal field `field_heading_level`

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/407
