### PR TITLE
YALB-1552: [admin-theme] Update specific checkbox styles for admin-theme areas

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -426,10 +426,11 @@
   color: var(--wool);
 }
 
-/* .gin--dark-mode .chosen-search-input,
-.gin--dark-mode .chosen-search-input::placeholder {
-  color: var(--dark-theme-gray) !important;
-} */
+.gin--dark-mode [data-drupal-selector^="views-ui-config-item-form-"] .js-form-type-checkbox,
+.gin--dark-mode .js-form-item-required,
+.gin--dark-mode .js-form-item-cas-enabled {
+  background-color: var(--darkest-gray);
+}
 
 /* search input placeholder opacity */
 input[type="search"]::placeholder {

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -59,7 +59,7 @@
   --gin-color-button-text: var(--dark-theme-gray);
   --gin-color-button-text-hover: var(--dark-theme-gray-hover);
   --gin-border-color-layer2: #A8A8A8 !important;
-  --gin-pattern-fallback: var(--wool);
+  --gin-pattern-fallback: var(--light-gray);
   --dropbutton-extrasmall-toggle-size: 1.5rem;
 }
 
@@ -190,6 +190,10 @@
 /* Media library */ 
 .media-library-item__click-to-select-checkbox .glb-form-checkbox:checked {
   background-color: var(--darkest-gray) !important;
+}
+
+.gin--dark-mode[dir="ltr"] .media-library-item img {
+  background-image: unset !important;
 }
 
 /* checkbox spacing */ 
@@ -517,11 +521,13 @@ input[type="search"]::placeholder {
   border: 0;
   padding: 0;
   width: 100%;
+  float: none;
 }
 
-.gin--dark-mode .fieldset-legend.fieldset__label {
+.gin--dark-mode .fieldset-legend.fieldset__label,
+.gin--dark-mode .fieldset__legend.fieldset__legend--visible .fieldset__label {
   display: block;
-  color: var(--darkest-gray);
+  color: var(--darkest-gray) !important;
   background-color: var(--wool);
   border-top-left-radius: 0.5rem;
   border-top-right-radius: 0.5rem;
@@ -531,6 +537,12 @@ input[type="search"]::placeholder {
   margin-left: -0.15rem;
   margin-right: -0.15rem;
 }
+
+.gin--dark-mode .fieldset__label.fieldset__label--group {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
 
 .gin--dark-mode #edit-footer-logos .fieldset-wrapper {
   padding: 1rem;
@@ -543,7 +555,6 @@ input[type="search"]::placeholder {
 .gin--dark-mode fieldset > legend + .fieldset-wrapper {
   padding: 1rem;
 }
-
 
 /* Secondary buttons */ 
 .gin--dark-mode .form-actions .button {
@@ -559,4 +570,10 @@ input[type="search"]::placeholder {
 .gin--dark-mode .messages,
 .gin--dark-mode .glb-messages {
   outline: 0.15rem solid var(--wool);
+}
+
+/* Radios */
+.gin--dark-mode .form-type--radio .form-radio {
+  border: 1px solid var(--wool);
+  background-color: var(--darkest-gray);
 }

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -498,7 +498,7 @@ input[type="search"]::placeholder {
 }
 
 .gin--dark-mode .form-boolean--type-checkbox:not(:checked) + .checkbox-toggle  .checkbox-toggle__inner {
-  background-color: var(--wool) !important;
+  background-color: var(--light-gray) !important;
 }
 
 /* Danger button */

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -426,11 +426,6 @@
   color: var(--wool);
 }
 
-.gin--dark-mode [data-drupal-selector^="views-ui-config-item-form-"] .js-form-type-checkbox,
-.gin--dark-mode .js-form-item-required,
-.gin--dark-mode .js-form-item-cas-enabled {
-  background-color: var(--darkest-gray);
-}
 
 /* search input placeholder opacity */
 input[type="search"]::placeholder {
@@ -489,12 +484,21 @@ input[type="search"]::placeholder {
   background-color: var(--darkest-gray) !important;
 }
 
-.gin--dark-mode .glb-form-checkbox:checked {
+/* checkboxes */
+.gin--dark-mode :not(.glb-form-checkboxes):not(td):not(.media-library-item__click-to-select-checkbox):not(.field-content) > .glb-form-checkbox:checked + .glb-checkbox-toggle {
+  background-color: var(--robin-egg) !important;
+}
+
+.gin--dark-mode :not(.form-checkboxes):not(td):not(.tabledrag-cell-content__item):not(.media-library-item__click-to-select-checkbox):not(.field-content) > .form-type--checkbox .checkbox-toggle__inner::before {
+  background-color: var(--dark-theme-gray) !important;
+}
+
+.gin--dark-mode :not(.form-checkboxes):not(td):not(.tabledrag-cell-content__item):not(.media-library-item__click-to-select-checkbox):not(.field-content) > .form-type--checkbox input:checked ~ .checkbox-toggle .checkbox-toggle__inner::before {
   background-color: var(--darkest-gray) !important;
 }
 
-.gin--dark-mode :not(.glb-form-checkboxes):not(td):not(.media-library-item__click-to-select-checkbox):not(.field-content) > .glb-form-checkbox:checked + .glb-checkbox-toggle {
-  background-color: var(--robin-egg) !important;
+.gin--dark-mode .form-boolean--type-checkbox:not(:checked) + .checkbox-toggle  .checkbox-toggle__inner {
+  background-color: var(--wool) !important;
 }
 
 /* Danger button */

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -509,3 +509,9 @@ input[type="search"]::placeholder {
 .gin--dark-mode .action-link--icon-trash.action-link--danger::before {
   background: var(--gin-color-danger) !important;
 }
+
+/* Messages */
+.gin--dark-mode .messages,
+.gin--dark-mode .glb-messages {
+  outline: 0.15rem solid var(--wool);
+}

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -173,27 +173,39 @@
   background-color: var(--wool);
 }
 
-.link:hover {
+.gin--dark-mode .glb-sidebar .link:hover,
+.gin--dark-mode .layout-builder .link:hover  {
   text-decoration: underline;
 }
 
-.link.tabledrag-toggle-weight {
+.gin--dark-mode .link.tabledrag-toggle-weight {
   color: var(--gin-color-primary);
   background-color: var(--darkest-gray);
 }
-
 
 .gin--dark-mode .glb-table .tabledrag-handle::after {
   background-color: var(--darkest-gray) !important;
 }
 
 /* Media library */ 
-.media-library-item__click-to-select-checkbox .glb-form-checkbox:checked {
+.gin--dark-mode .media-library-item__click-to-select-checkbox .glb-form-checkbox:checked {
   background-color: var(--darkest-gray) !important;
 }
 
 .gin--dark-mode[dir="ltr"] .media-library-item img {
   background-image: unset !important;
+}
+
+.gin--dark-mode .media-library-item .form-item {
+  border: 2px solid var(--darkest-gray);
+  padding: 0;
+  border-radius: 0.25rem;
+}
+
+.gin--dark-mode .media-library-item .media-library-item__remove:link,
+.gin--dark-mode .media-library-item .media-library-item__remove:not(:hover):not(:checked),
+.gin--dark-mode .media-library-item .media-library-item__edit:not(:hover):not(:checked) {
+  border-color: var(--darkest-gray) !important;
 }
 
 /* checkbox spacing */ 

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -510,6 +510,51 @@ input[type="search"]::placeholder {
   background: var(--gin-color-danger) !important;
 }
 
+/* Legend */
+.gin--dark-mode legend {
+  display: block;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.gin--dark-mode .fieldset-legend.fieldset__label {
+  display: block;
+  color: var(--darkest-gray);
+  background-color: var(--wool);
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  border: 0.15rem solid var(--gin-border-color);
+  margin-left: -0.15rem;
+  margin-right: -0.15rem;
+}
+
+.gin--dark-mode #edit-footer-logos .fieldset-wrapper {
+  padding: 1rem;
+}
+
+.gin--dark-mode #edit-footer-logos fieldset + .form-item {
+  margin-top: 1rem;
+}
+
+.gin--dark-mode fieldset > legend + .fieldset-wrapper {
+  padding: 1rem;
+}
+
+
+/* Secondary buttons */ 
+.gin--dark-mode .form-actions .button {
+  color: var(--gin-color-primary);
+  background-color: var(--darkest-gray);
+}
+
+.gin--dark-mode .form-actions .button:focus {
+  background-color: var(--wool);
+}
+
 /* Messages */
 .gin--dark-mode .messages,
 .gin--dark-mode .glb-messages {


### PR DESCRIPTION
## [YALB-1552: [admin-theme] Update specific checkbox styles for admin-theme areas](https://yaleits.atlassian.net/browse/YALB-1552)

### Description of work
- Adds styling for specific checkbox instances where contrast is an issue (depends on where a checkbox is placed and varies with module use)

### Functional testing steps:
- [x] Review here: https://github.com/yalesites-org/yalesites-project/pull/410