### PR TITLE
YALB-1057: Bug: Smart quotes issue on heading fields

### DIFF
--- a/templates/block/layout-builder/block--inline-block--custom-cards.html.twig
+++ b/templates/block/layout-builder/block--inline-block--custom-cards.html.twig
@@ -3,7 +3,7 @@
 {% block content %}
 
   {% embed "@organisms/custom-card-collection/yds-custom-card-collection.twig" with {
-    custom_card_collection__heading: content.field_heading.0,
+    custom_card_collection__heading: content.field_heading.0['#text'],
     custom_card_collection__width: 'site',
   } %}
     {% block custom_card_collection__cards %}

--- a/templates/block/layout-builder/block--inline-block--directory.html.twig
+++ b/templates/block/layout-builder/block--inline-block--directory.html.twig
@@ -15,6 +15,6 @@
     'data-collection-type': 'list',
     class: bem(view__base_class, view__modifiers),
   } %}
-  {{ drupal_view('directory', 'block_1', content.field_heading.0) }}
+  {{ drupal_view('directory', 'block_1', content.field_heading.0['#text']) }}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--event-list.html.twig
+++ b/templates/block/layout-builder/block--inline-block--event-list.html.twig
@@ -16,6 +16,6 @@
     class: bem(view__base_class, view__modifiers),
   } %}
 
-  {{ drupal_view('event_list', 'full', content.field_heading.0) }}
+  {{ drupal_view('event_list', 'full', content.field_heading.0['#text']) }}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--post-list.html.twig
+++ b/templates/block/layout-builder/block--inline-block--post-list.html.twig
@@ -15,6 +15,6 @@
     'data-collection-type': 'list',
     class: bem(view__base_class, view__modifiers),
   } %}
-  {{ drupal_view('post_list', 'full', content.field_heading.0) }}
+  {{ drupal_view('post_list', 'full', content.field_heading.0['#text']) }}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--quick-links.html.twig
+++ b/templates/block/layout-builder/block--inline-block--quick-links.html.twig
@@ -12,7 +12,7 @@
 
   {% embed "@molecules/quick-links/yds-quick-links.twig" with {
     quick_links__variation: 'promotional',
-    quick_links__heading: content.field_heading.0,
+    quick_links__heading: content.field_heading.0['#text'],
     quick_links__description: content.field_text.0,
     quick_links__image: content.field_media.0,
     quick_links__links: content.field_links.0,

--- a/templates/paragraphs/paragraph--custom-card.html.twig
+++ b/templates/paragraphs/paragraph--custom-card.html.twig
@@ -3,7 +3,7 @@
 {% set custom_card__image = content.field_image.0 ? 'true' : 'false' %}
 
 {% embed "@molecules/cards/custom-card/yds-custom-card.twig" with {
-  custom_card__heading: content.field_heading.0,
+  custom_card__heading: content.field_heading.0['#text'],
   custom_card__snippet: content.field_text.0,
   custom_card__url: content.field_link.0['#url_title'],
 } %}


### PR DESCRIPTION
## [YALB-1057: Bug: Smart quotes issue on heading fields](https://yaleits.atlassian.net/browse/YALB-1057)

### Description of work
- Reverting the application of smart quotes on heading fields as this is causing a problem when these fields are used in components. It is possible we want to change the other text fields in the future. For now, we are keeping the scope small. This change ensure that text (not an object) is passed to the drupal view.
- This is revering work originally committed in this PR https://github.com/yalesites-org/atomic/pull/168/files
