### PR TITLE
YALB-1559: Bug: fontawesome fonts included in multidevs but not releases

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -50,9 +50,9 @@ background-video:
 fontawesome:
   css:
     theme:
-      node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/fontawesome.css: {}
-      node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/regular.css: {}
-      node_modules/@yalesites-org/component-library-twig/fonts/fontawesome/css/solid.css: {}
+      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/fontawesome.css: {}
+      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/regular.css: {}
+      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/solid.css: {}
 
 layout-builder:
   css:


### PR DESCRIPTION
## [YALB-1559: Bug: fontawesome fonts included in multidevs but not releases](https://yaleits.atlassian.net/browse/YALB-1559)

### Description of work
- Updates fontawesome font paths to load from `/dist` directory of component-library-twig per change in https://github.com/yalesites-org/component-library-twig/pull/295

### Functional testing steps:
- [x] In PR from yalesites-project, verify fontawesome icons are displaying where expected in the generated multidev
