### PR TITLE
fix(YALB-email-copy-change-to-button): add new library

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -62,3 +62,7 @@ layout-builder:
 text-link:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/controls/text-link/yds-text-link.js: {}
+
+text-copy-button:
+  js:
+    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/controls/text-copy-button/yds-text-copy-button.js: {}


### PR DESCRIPTION
## Release fixes noted in Teams.

### Description of work

> HIGH PRIORITY! Copy button for email link in Profile is not receiving focus and is not tabbable- (should be a button and not a link) @joetower

- Adds a new separate component for copy text link so that we can change the element from an `a` to a `button`. Also, it helps make the text-link component much more lean and makes the new component more purposeful. 

#### Includes: 
- https://github.com/yalesites-org/component-library-twig/pull/297
- https://github.com/yalesites-org/yalesites-project/pull/433

#### Will merge in to: https://github.com/yalesites-org/atomic/pull/174


### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/433
