### PR TITLE
YALB-1527 - Bug: Update link styling "Skip to Main Content" | YALB-1560 - Blank space in toolbar on admin theme

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -442,6 +442,9 @@
   color: var(--wool);
 }
 
+.gin--dark-mode .chosen-container-single .chosen-search input[type="text"] {
+  color: var(--darkest-gray);
+}
 
 /* search input placeholder opacity */
 input[type="search"]::placeholder {

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -1,0 +1,51 @@
+{#
+/**
+ * @file
+ * Theme override for the basic structure of a single Drupal page.
+ *
+ * Variables:
+ * - logged_in: A flag indicating if user is logged in.
+ * - root_path: The root path of the current page (e.g., node, admin, user).
+ * - node_type: The content type for the current node, if the page is a node.
+ * - head_title: List of text elements that make up the head_title variable.
+ *   May contain one or more of the following:
+ *   - title: The title of the page.
+ *   - name: The name of the site.
+ *   - slogan: The slogan of the site.
+ * - page_top: Initial rendered markup. This should be printed before 'page'.
+ * - page: The rendered page markup.
+ * - page_bottom: Closing rendered markup. This variable should be printed after
+ *   'page'.
+ * - db_offline: A flag indicating if the database is offline.
+ * - placeholder_token: The token for generating head, css, js and js-bottom
+ *   placeholders.
+ *
+ * @see template_preprocess_html()
+ */
+#}
+<!DOCTYPE html>
+<html{{ html_attributes }}>
+  <head>
+    <head-placeholder token="{{ placeholder_token|raw }}">
+    <title>{{ head_title|safe_join(' | ') }}</title>
+    <css-placeholder token="{{ placeholder_token|raw }}">
+    <js-placeholder token="{{ placeholder_token|raw }}">
+  </head>
+  <body{{ attributes }}>
+    {#
+      Keyboard navigation/accessibility link to main content section in
+      page.html.twig.
+    #}
+
+    {% include "@molecules/link-skip/yds-link-skip.twig" with {
+      link_skip__content: 'Skip to main content'|t ,
+      link_skip__url: '#main-content',
+      link_skip__extra_class: 'visually-hidden focusable',
+    }%}
+
+    {{ page_top }}
+    {{ page }}
+    {{ page_bottom }}
+    <js-bottom-placeholder token="{{ placeholder_token|raw }}">
+  </body>
+</html>


### PR DESCRIPTION
## [YALB-1527 - Bug: Update link styling "Skip to Main Content"](https://yaleits.atlassian.net/browse/YALB-1527)
## [YALB-1560 - Blank space in toolbar on admin theme](https://yaleits.atlassian.net/browse/YALB-1560)

### Description of work
- Adds a component for `link skip`: 
- Wires new link skip to `html.html` template.
- Fixes chosen input search colors on `admin/content` tags

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/438
