### PR TITLE
YALB-1624 - Bug: Footer placement off when short page has visually hidden title

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -90,3 +90,8 @@ display: flex;
 .block-wrapper .text p {
   margin: 0;
 } 
+
+/* Get sticky footer to work in Layout Builder */
+#block-yalesitesfooterblock {
+  margin-top: auto;
+}


### PR DESCRIPTION
## [YALB-1624 - Bug: Footer placement off when short page has visually hidden title](https://yaleits.atlassian.net/browse/YALB-1624)

### Description of work
- Adds `margin-top: auto` to the layout-builder.css file to make the footer "hug" the bottom of the browser window
- This issue was caused by `site-footer` being wrapped in a new `div` `#block-yalesitesfooterblock`

### Functional testing steps:
- [x] Test a page with little content, such as this one here: https://pr-472-yalesites-platform.pantheonsite.io/short-page
- [x] Verify the footer is pushed down to the bottom of the browser window

<img width="2038" alt="Screenshot 2023-11-02 at 8 43 07 AM" src="https://github.com/yalesites-org/atomic/assets/366413/f20b8208-ba39-4eef-9b33-51fc90ec3766">

