### PR TITLE
YALB-1661: Profile media image being used for page and view block

### DIFF
--- a/templates/node/node--profile--card.html.twig
+++ b/templates/node/node--profile--card.html.twig
@@ -10,11 +10,12 @@
   reference_card__image: 'true',
 } %}
   {% block reference_card__image %}
-
-    {% if content.field_media[0] %}
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif content.field_media[0] %}
       {{ content.field_media }}
     {% elseif getCoreSetting('image_fallback.teaser') %}
-      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'profile_directory_card_1_1_') }}
     {% endif %}
 
   {% endblock %}

--- a/templates/node/node--profile--directory.html.twig
+++ b/templates/node/node--profile--directory.html.twig
@@ -14,10 +14,12 @@
 } %}
 
   {% block directory_listing_card__image %}
-    {% if content.field_media[0] %}
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif content.field_media[0] %}
       {{ content.field_media }}
     {% elseif getCoreSetting('image_fallback.teaser') %}
-      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'profile_directory_card_1_1_') }}
     {% endif %}
   {% endblock %}
 

--- a/templates/node/node--profile--list-item.html.twig
+++ b/templates/node/node--profile--list-item.html.twig
@@ -9,11 +9,12 @@
   reference_card__snippet: content.field_subtitle,
 } %}
   {% block reference_card__image %}
-
-    {% if content.field_media[0] %}
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif content.field_media[0] %}
       {{ content.field_media }}
     {% elseif getCoreSetting('image_fallback.teaser') %}
-      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'profile_directory_card_1_1_') }}
     {% endif %}
 
   {% endblock %}


### PR DESCRIPTION
## [YALB-1661: Profile media image being used for page and view block](https://yaleits.atlassian.net/browse/YALB-1661)

### Description of work
- Adds a fallback image if someone doesn't add a profile image or a teaser image to a profile node.  

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/503