### PR TITLE
YALB-1650 - Reusable Content: Browser UX

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -90,3 +90,21 @@ display: flex;
 .block-wrapper .text p {
   margin: 0;
 } 
+
+
+/* Wingsuit layout builder styles */
+
+.block-categories .layout-builder-browser-block-item img {
+  width: 100%;
+  margin-bottom: 1rem;
+  filter: unset;
+}
+
+.block-categories.glb-layout-builder-browser .glb-claro-details__wrapper {
+  justify-content: space-between;
+}
+
+.block-categories .layout-builder-browser-block-item {
+  width: 100%;
+  max-width: 30%;
+}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -129,6 +129,10 @@ display: flex;
   flex-grow: unset;
 }
 
-.layout-builder-configure-block .form-item-reusable {
+/* Used with patch to add reusable blocks from within layout builder */
+
+.layout-builder-configure-block .form-item-reusable,
+.layout-builder-configure-block .form-item-reusable + .form-type--textfield {
   padding-left: 20px;
+  padding-right: 21px;
 }

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -124,3 +124,11 @@ display: flex;
 .layout-builder-browser-reusable-block .underlined-title {
   text-decoration: underline;
 }
+
+.glb-canvas-form__settings {
+  flex-grow: unset;
+}
+
+.layout-builder-configure-block .form-item-reusable {
+  padding-left: 20px;
+}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -101,10 +101,10 @@ display: flex;
 }
 
 .block-categories.glb-layout-builder-browser .glb-claro-details__wrapper {
-  justify-content: space-between;
+  gap: 0.5rem;
 }
 
 .block-categories .layout-builder-browser-block-item {
   width: 100%;
-  max-width: 30%;
+  max-width: calc(33% - 1rem);
 }

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -129,10 +129,15 @@ display: flex;
   flex-grow: unset;
 }
 
-/* Used with patch to add reusable blocks from within layout builder */
+/*
+Used with patch to add reusable blocks from within layout builder
+Note: div[data-drupal-selector="edit-block-form"] is for reusable block editing
+area needed more padding.
+*/
 
 .layout-builder-configure-block .form-item-reusable,
-.layout-builder-configure-block .form-item-reusable + .form-type--textfield {
+.layout-builder-configure-block .form-item-reusable + .form-type--textfield,
+div[data-drupal-selector="edit-block-form"] {
   padding-left: 20px;
   padding-right: 21px;
 }

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -6,19 +6,19 @@
 Edit overrides 1
 ****************
 
-first and last child component spacing between the 
-site header and site footer, respectively. 
+first and last child component spacing between the
+site header and site footer, respectively.
 
 ****************
 ****************
 */
 
 
-/* This `layout-banner override, overrides the .main-content > *:first-child 
-statement in web/themes/contrib/atomic/_yale-packages/component-library-twig/components/04-page-layouts/page-layouts.scss 
+/* This `layout-banner override, overrides the .main-content > *:first-child
+statement in web/themes/contrib/atomic/_yale-packages/component-library-twig/components/04-page-layouts/page-layouts.scss
 
 We need to set this region to have no top margin because our component-library doesn't
-account for div elements in-between 'main-content' and the component themselves. 
+account for div elements in-between 'main-content' and the component themselves.
 
 Without this, the `layout-banner` would get top margin from the component-library
 because the --main-content-top-margin variable isn't set and --size-spacing-6
@@ -42,7 +42,7 @@ would be used instead resulting in top margin of size-spacing-6.  */
   margin-bottom: var(--main-content-bottom-margin, var(--size-spacing-13));
 }
 
-/* Here we need to specify which components in the main content layout div 
+/* Here we need to specify which components in the main content layout div
 need to have margin-bottom set to 0 */
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .callouts:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .cta-banner:last-child,
@@ -52,15 +52,15 @@ need to have margin-bottom set to 0 */
 }
 
 /* This is necessary because there could be more than one instance of
-// layout-onecol 
+// layout-onecol
 */
 .main-content .layout.layout--onecol:last-child {
   margin-bottom: 0;
 }
 
 /*
-// Pull quotes has a <p> element provided by the WYSIWYG 
-// we need to make the `-` character and the attribution text in line, 
+// Pull quotes has a <p> element provided by the WYSIWYG
+// we need to make the `-` character and the attribution text in line,
 // and remove margin from the <p>
 display: flex;
 */
@@ -89,7 +89,7 @@ display: flex;
 /* Remove margin from `p` element when used in sidebar */
 .block-wrapper .text p {
   margin: 0;
-} 
+}
 
 
 /* Wingsuit layout builder styles */
@@ -113,5 +113,14 @@ display: flex;
   .block-categories .layout-builder-browser-block-item {
     max-width: calc(33% - 1rem);
   }
-  
+
+}
+
+.layout-builder-browser-reusable-block {
+  text-decoration: none;
+  line-height: 1.5rem;
+}
+
+.layout-builder-browser-reusable-block .underlined-title {
+  text-decoration: underline;
 }

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -106,5 +106,12 @@ display: flex;
 
 .block-categories .layout-builder-browser-block-item {
   width: 100%;
-  max-width: calc(33% - 1rem);
+  max-width: calc(50% - 1rem);
+}
+
+@media screen and (min-width: 500px) {
+  .block-categories .layout-builder-browser-block-item {
+    max-width: calc(33% - 1rem);
+  }
+  
 }

--- a/templates/block/layout-builder/_layout-builder-block-template.twig
+++ b/templates/block/layout-builder/_layout-builder-block-template.twig
@@ -1,15 +1,17 @@
-{# If we're in layout-builder, we need to add/wrap a '<div>' around each 
+{# If we're in layout-builder, we need to add/wrap a '<div>' around each
 component to make them drag-n-droppable #}
 {% if attributes.hasClass('js-layout-builder-block') %}
 
-  {# Set a variable to true if we're in in_layout_builder so that we can 
-  close the div after the block content instance, which removes all attributes because of 
-  emulsify_twig. Without this the div can't close by checking 
+  {# Set a variable to true if we're in in_layout_builder so that we can
+  close the div after the block content instance, which removes all attributes because of
+  emulsify_twig. Without this the div can't close by checking
     {% if attributes.hasClass('js-layout-builder-block') %}
    #}
   {% set in_layout_builder = TRUE %}
 
-  <div{{ attributes }}>
+  {% set reusable_class = is_reusable ? 'ys-layout-builder--is-reusable' %}
+
+  <div{{ attributes.addClass(reusable_class) }}>
     {{ attach_library('ys_themes/ys_themes') }}
     <div class="ys-layout-builder--drag-drop">
     </div>

--- a/templates/block/layout-builder/block--broken.html.twig
+++ b/templates/block/layout-builder/block--broken.html.twig
@@ -1,0 +1,21 @@
+{% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
+
+{% block content %}
+
+  {% if parentNode == 'post' or parentNode == 'event' %}
+    {% set text_field__width = "content" %}
+    {% set text_field__alignment = "center" %}
+  {% else %}
+    {% set text_field__width = "site" %}
+    {% set text_field__alignment = "left" %}
+  {% endif %}
+
+  {% embed "@molecules/text/yds-text-field.twig" with {
+    text_field__content: "This Reusable Block has been deleted. Remove this instance of the deleted block.",
+    text_field__width: text_field__width,
+    text_field__alignment: text_field__alignment,
+    text_field__variation: content.field_style_variation.0['#markup'],
+  } %}
+  {% endembed %}
+
+{% endblock %}


### PR DESCRIPTION
## [YALB-1650 - Reusable Content: Browser UX](https://yaleits.atlassian.net/browse/YALB-1650)

### Description of work
- Adds custom styles now that we've removed wingsuit

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/506
- [ ] Edit a page like `node/26/layout`
- [ ] Add a component block and confirm the components are in three columns
<img width="2475" alt="Screenshot 2023-12-13 at 4 22 41 PM" src="https://github.com/yalesites-org/atomic/assets/366413/cf6b498b-9da6-4e00-a0d0-c03185b09500">

