### PR TITLE
YALB-1306: Emphasized text - Wiring

### DIFF
--- a/templates/block/layout-builder/block--inline-block--text.html.twig
+++ b/templates/block/layout-builder/block--inline-block--text.html.twig
@@ -14,6 +14,7 @@
     text_field__content: content.field_text,
     text_field__width: text_field__width,
     text_field__alignment: text_field__alignment,
+    text_field__variation: content.field_style_variation.0['#markup'],
   } %}
   {% endembed %}
 


### PR DESCRIPTION
## [YALB-1306: Emphasized text](https://yaleits.atlassian.net/browse/YALB-1306)

### Description of work
- Adds variation option to the `text` component for `emphasized`
- Themes the emphasized variation to use the body-xl style: https://yalesites-org.github.io/component-library-twig/?path=/story/tokens-typography--body-styles
- Note branched PRs in Atomic and Component library:
- https://github.com/yalesites-org/atomic/pull/191
 - https://github.com/yalesites-org/component-library-twig/pull/315
 

### Functional testing steps:
- [ ] Test in main PR here: https://github.com/yalesites-org/yalesites-project/pull/508