### PR TITLE
YALB-1674: add new content spotlight portrait component | YALB-1675: Feedback: Content Spotlight - inline/offset image dial | YALB-1676: Feedback: Content Spotlight portrait image treatment

### DIFF
--- a/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
@@ -1,0 +1,20 @@
+{% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
+
+{% block content %}
+
+  {% embed "@molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig" with {
+      content_spotlight_portrait__heading: content.field_heading,
+      content_spotlight_portrait__subheading: content.field_subheading,
+      content_spotlight_portrait__text: content.field_text,
+      content_spotlight_portrait__link__content: content.field_link.0['#title'],
+      content_spotlight_portrait__link__url: content.field_link.0['#url_title'],
+      content_spotlight_portrait__style: content.field_style_variation.0['#markup'],
+      content_spotlight_portrait__position: content.field_style_position.0['#markup'],
+      content_spotlight_portrait__theme: content.field_style_color.0['#markup'],
+  }%}
+
+    {% block content_spotlight_portrait__image %}
+      {{ content.field_media }}
+    {% endblock %}
+  {% endembed %}
+{% endblock %}

--- a/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
@@ -11,6 +11,7 @@
     text_with_image__focus: content.field_style_variation.0['#markup'],
     text_with_image__position: content.field_style_position.0['#markup'],
     text_with_image__width: content.field_style_width.0['#markup'],
+    text_with_image__theme: content.field_style_color.0['#markup'],
   } %}
 
     {% block text_with_image__image %}


### PR DESCRIPTION
## [YALB-1674: Feedback: Content spotlight background color dial](https://yaleits.atlassian.net/browse/YALB-1674)
## [YALB-1675: Feedback: Content Spotlight - inline/offset image dial](https://yaleits.atlassian.net/browse/YALB-1675)
## [YALB-1676: Feedback: Content Spotlight portrait image treatment](https://yaleits.atlassian.net/browse/YALB-1676)

### Description of work
- Adds a new component called "Content Spotlight (Portrait)"
- Uses a 2:3 aspect ratio image for content spotlight image
- Enables color theme selection dial on Content Spotlight (Portrait)
- Adds new 2:3 aspect ratio responsive image style and image styles

### Functional testing steps:
- [ ] Review here: https://github.com/yalesites-org/yalesites-project/pull/514
