### PR TITLE
YALB-520: Links: Dynamically apply link treatments

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -8,6 +8,7 @@ global:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/menu/menu-toggle/yds-menu-toggle.js: {}
     node_modules/@yalesites-org/component-library-twig/dist/js/00-tokens/layout/yds-layout.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/ys-link.js: {}
   dependencies:
     - core/drupal
 


### PR DESCRIPTION
## [YALB-520: Links: Dynamically apply link treatments](https://yaleits.atlassian.net/browse/YALB-520)

MultiDev PR: https://github.com/yalesites-org/yalesites-project/pull/467
Component Library PR: https://github.com/yalesites-org/component-library-twig/pull/319
Atomic PR: https://github.com/yalesites-org/atomic/compare/YALB-520-links-dynamically-apply-link-treatments

### Description of work
- Adds javascript sprinkles to identify and modify links on page to match component-library-twig links
- Links decorated:
  - External
  - Downloads
  - Target Blank