### PR TITLE
YALB-680: Links: Link to external content in lists of cards 

### DIFF
--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -16,6 +16,8 @@
 
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
 {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
   reference_card__heading: heading,
   reference_card__subheading: date__formatted,

--- a/templates/node/node--event--condensed.html.twig
+++ b/templates/node/node--event--condensed.html.twig
@@ -2,6 +2,7 @@
 
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 {% set reference_card__image = 'false' %}
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
 {% set date__formatted %}
   {% include "@atoms/date-time/yds-date-time.twig" with {

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -16,6 +16,8 @@
 
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
 {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
   reference_card__heading: heading,
   reference_card__subheading: date__formatted,

--- a/templates/node/node--search-result.html.twig
+++ b/templates/node/node--search-result.html.twig
@@ -1,3 +1,5 @@
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
 {% include "@molecules/search-result/yds-search-result.twig" with {
   search_result__title: label,
   search_result__url: url,


### PR DESCRIPTION
## [YALB-680: Links: Link to external content in lists of cards ](https://yaleits.atlassian.net/browse/YALB-680)

### Description of work
- Wires new field_external_source to URL if available, otherwise it sets `url` to `url`. 

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/552
