### PR TITLE
 YALB-1697: Bug: Margin for spotlights

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -1,59 +1,73 @@
 global:
   css:
     theme:
-      'https://yale-webfonts.yalespace.org/fonts.min.css': { type: external }
+      "https://yale-webfonts.yalespace.org/fonts.min.css": { type: external }
       node_modules/@yalesites-org/component-library-twig/dist/style.css: {}
       components/_settings/_config.css: {}
       css/admin-theme.css: {}
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/menu/menu-toggle/yds-menu-toggle.js: {}
-    node_modules/@yalesites-org/component-library-twig/dist/js/00-tokens/layout/yds-layout.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/menu/menu-toggle/yds-menu-toggle.js:
+      {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/00-tokens/layout/yds-layout.js:
+      {}
     node_modules/@yalesites-org/component-library-twig/dist/js/ys-link.js: {}
   dependencies:
     - core/drupal
 
 accordion:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/accordion/yds-accordion.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/accordion/yds-accordion.js:
+      {}
 
 alert:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/alert/yds-alert.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/alert/yds-alert.js:
+      {}
 
 primary-nav:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/primary-nav/yds-primary-nav.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/primary-nav/yds-primary-nav.js:
+      {}
 
 reference-card:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/cards/reference-card/yds-reference-card.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/cards/reference-card/yds-reference-card.js:
+      {}
 
 custom-card:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/cards/custom-card/yds-custom-card.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/cards/custom-card/yds-custom-card.js:
+      {}
 
 breadcrumbs:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/breadcrumbs/yds-breadcrumbs.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/breadcrumbs/yds-breadcrumbs.js:
+      {}
 
 tabs:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/tabs/yds-tabs.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/tabs/yds-tabs.js:
+      {}
 
 gallery:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/galleries/media-grid/yds-media-grid-interactive.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/galleries/media-grid/yds-media-grid-interactive.js:
+      {}
 
 background-video:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/videos/video-background/yds-video-background.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/videos/video-background/yds-video-background.js:
+      {}
 
 fontawesome:
   css:
     theme:
-      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/fontawesome.css: {}
-      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/regular.css: {}
-      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/solid.css: {}
+      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/fontawesome.css:
+        {}
+      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/regular.css:
+        {}
+      node_modules/@yalesites-org/component-library-twig/dist/fonts/fontawesome/css/solid.css:
+        {}
 
 layout-builder:
   css:
@@ -62,8 +76,14 @@ layout-builder:
 
 text-link:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/controls/text-link/yds-text-link.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/controls/text-link/yds-text-link.js:
+      {}
 
 text-copy-button:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/controls/text-copy-button/yds-text-copy-button.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/controls/text-copy-button/yds-text-copy-button.js:
+      {}
+spotlights:
+  js:
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/content-spotlight-portrait/content-spotlights.js:
+      {}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -47,7 +47,9 @@ need to have margin-bottom set to 0 */
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .callouts:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .cta-banner:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .grand-hero-banner:last-child,
-.main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .quick-links:last-child {
+.main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .quick-links:last-child,
+.main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .text-with-image:not([data-component-theme='default']):last-child, 
+.main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .content-spotlight-portrait:not([data-component-theme='default']):last-child {
   margin-bottom: 0;
 }
 

--- a/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
@@ -1,6 +1,7 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
+  {{ attach_library('atomic/spotlights') }}
 
   {% embed "@molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig" with {
       content_spotlight_portrait__heading: content.field_heading,

--- a/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
@@ -1,6 +1,7 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
+  {{ attach_library('atomic/spotlights') }}
 
   {% embed "@molecules/text-with-image/yds-text-with-image.twig" with {
     text_with_image__heading: content.field_heading,


### PR DESCRIPTION
## [YALB-1697: Bug: Margin for spotlights](https://yaleits.atlassian.net/browse/YALB-1697)

### Description of work
- Adds new library for spotlight component JS
- Attaches the library to the two spotlight component block templates

### Functional testing steps:
- [ ] Review here: https://github.com/yalesites-org/component-library-twig/pull/332
