### PR TITLE
YSP-277: Spotlight without header shows an empty h tag

### DIFF
--- a/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
@@ -1,10 +1,9 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
-
   {% embed "@molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig" with {
-      content_spotlight_portrait__heading: content.field_heading,
-      content_spotlight_portrait__subheading: content.field_subheading,
+      content_spotlight_portrait__heading: content.field_heading.0,
+      content_spotlight_portrait__subheading: content.field_subheading.0,
       content_spotlight_portrait__text: content.field_text,
       content_spotlight_portrait__link__content: content.field_link.0['#title'],
       content_spotlight_portrait__link__url: content.field_link.0['#url_title'],

--- a/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
@@ -3,8 +3,8 @@
 {% block content %}
 
   {% embed "@molecules/text-with-image/yds-text-with-image.twig" with {
-    text_with_image__heading: content.field_heading,
-    text_with_image__subheading: content.field_subheading,
+    text_with_image__heading: content.field_heading.0,
+    text_with_image__subheading: content.field_subheading.0,
     text_with_image__text: content.field_text,
     text_with_image__link__content: content.field_link.0['#title'],
     text_with_image__link__url: content.field_link.0['#url_title'],

--- a/templates/block/layout-builder/block--inline-block--custom-cards.html.twig
+++ b/templates/block/layout-builder/block--inline-block--custom-cards.html.twig
@@ -3,7 +3,7 @@
 {% block content %} 
 
   {% embed "@organisms/custom-card-collection/yds-custom-card-collection.twig" with {
-    custom_card_collection__heading: content.field_heading.0,
+    custom_card_collection__heading: content.field_heading.0['#text'],
     custom_card_collection__width: 'site',
   } %}
     {% block custom_card_collection__cards %}

--- a/templates/block/layout-builder/block--inline-block--custom-cards.html.twig
+++ b/templates/block/layout-builder/block--inline-block--custom-cards.html.twig
@@ -1,9 +1,9 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
-{% block content %}
+{% block content %} 
 
   {% embed "@organisms/custom-card-collection/yds-custom-card-collection.twig" with {
-    custom_card_collection__heading: content.field_heading.0['#text'],
+    custom_card_collection__heading: content.field_heading.0,
     custom_card_collection__width: 'site',
   } %}
     {% block custom_card_collection__cards %}


### PR DESCRIPTION
## [YSP-277: Spotlight without header shows an empty h tag](https://yaleits.atlassian.net/browse/YSP-277)

### Description of work
- Wire the heading and subheading field for conditional logic

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/component-library-twig/pull/334