### PR TITLE
YSP-275: Long email breaks Profile card grid: update wired variables

### DIFF
--- a/templates/node/node--profile--directory.html.twig
+++ b/templates/node/node--profile--directory.html.twig
@@ -12,7 +12,7 @@
     directory_listing_card__email: content.field_email,
     directory_listing_card__phone: content.field_telephone,
     directory_listing_card_link__content: directory_listing_card_link__content,
-    directory_listing_card_link__url: 'mailto:' ~ content.field_email[0]['#context'].value,
+    directory_listing_card_link__url: 'mailto:' ~ content.field_email[0]['#context'].value|trim|lower,
 } %}
 
   {% block directory_listing_card__image %}

--- a/templates/node/node--profile--directory.html.twig
+++ b/templates/node/node--profile--directory.html.twig
@@ -10,7 +10,9 @@
     directory_listing_card__subheading: content.field_position,
     directory_listing_card__snippet: content.field_subtitle,
     directory_listing_card__email: content.field_email,
-    directory_listing_card__phone: content.field_telephone
+    directory_listing_card__phone: content.field_telephone,
+    directory_listing_card_link__content: directory_listing_card_link__content,
+    directory_listing_card_link__url: 'mailto:' ~ content.field_email[0]['#context'].value,
 } %}
 
   {% block directory_listing_card__image %}


### PR DESCRIPTION
## [YSP-275: Long email breaks Profile card grid](https://yaleits.atlassian.net/browse/YSP-275)

### Description of work
- Wires `directory_listing_card_link__url` to `'mailto:' ~ content.field_email[0]['#context'].value|trim|lower`

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/component-library-twig/pull/335

