### PR TITLE
fix(YSP-275): pass email fallback value

### DIFF
--- a/templates/node/node--profile--directory.html.twig
+++ b/templates/node/node--profile--directory.html.twig
@@ -10,7 +10,7 @@
     directory_listing_card__overline: content.field_department,
     directory_listing_card__subheading: content.field_position,
     directory_listing_card__snippet: content.field_subtitle,
-    directory_listing_card__email: content.field_email,
+    directory_listing_card__email: content.field_email[0]['#context'].value|trim|lower,
     directory_listing_card__phone: content.field_telephone,
     directory_listing_card_link__content: directory_listing_card_link__content,
     directory_listing_card_link__url: 'mailto:' ~ content.field_email[0]['#context'].value|trim|lower,


### PR DESCRIPTION
While this was working, passing the array of the email through was causing a warning to be displayed.  The URL was properly done to get the value to pass through, so we are doing the same for the email, removing the array passing warning.

## [YSP-275: Long email breaks Profile card grid](https://yaleits.atlassian.net/browse/YSP-275)

### Description of work
- Pass the email value over the email array

### Functional testing steps:
- [ ] Create a profile
- [ ] Create a directory of profiles
- [ ] Ensure that no warnings occur and that the email address is clickable of the profile
