### PR TITLE
YSP-375: TwigTweak errors when removing media used in gallery

### DIFF
--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -7,6 +7,8 @@
       {% block media_grid_item__media %}
         {% if (item.entity.field_media.0.entity.mid != NULL) %}
           {{ drupal_entity('media', item.entity.field_media.0.entity.mid.value, 'card_secondary_3_2') }}
+        {% elseif getCoreSetting('image_fallback.teaser') %}
+          {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
         {% else %}
           {{ "Missing image" }}
         {% endif %}

--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -5,7 +5,11 @@
       media_grid__variation: 'interactive',
     } %}
       {% block media_grid_item__media %}
-        {{ drupal_entity('media', item.entity.field_media.0.entity.mid.value, 'card_secondary_3_2') }}
+        {% if (item.entity.field_media.0.entity.mid != NULL) %}
+          {{ drupal_entity('media', item.entity.field_media.0.entity.mid.value, 'card_secondary_3_2') }}
+        {% else %}
+          {{ "Missing image" }}
+        {% endif %}
       {% endblock %}
     {% endembed %}
   {% endfor %}

--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -8,7 +8,7 @@
         {% if (item.entity.field_media.0.entity.mid != NULL) %}
           {{ drupal_entity('media', item.entity.field_media.0.entity.mid.value, 'card_secondary_3_2') }}
         {% else %}
-          Missing image
+          {% include "@atoms/images/image/_image.twig" %}
         {% endif %}
       {% endblock %}
     {% endembed %}

--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -7,10 +7,8 @@
       {% block media_grid_item__media %}
         {% if (item.entity.field_media.0.entity.mid != NULL) %}
           {{ drupal_entity('media', item.entity.field_media.0.entity.mid.value, 'card_secondary_3_2') }}
-        {% elseif getCoreSetting('image_fallback.teaser') %}
-          {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
         {% else %}
-          {{ "Missing image" }}
+          Missing image
         {% endif %}
       {% endblock %}
     {% endembed %}

--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -8,7 +8,7 @@
         {% if (item.entity.field_media.0.entity.mid != NULL) %}
           {{ drupal_entity('media', item.entity.field_media.0.entity.mid.value, 'card_secondary_3_2') }}
         {% elseif getCoreSetting('image_fallback.teaser') %}
-          {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
+          {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
         {% else %}
           {{ "Missing image" }}
         {% endif %}

--- a/templates/paragraphs/paragraph--gallery-item--gallery-modal-media.html.twig
+++ b/templates/paragraphs/paragraph--gallery-item--gallery-modal-media.html.twig
@@ -1,7 +1,5 @@
 {% if (content.field_media.0) %}
   {{ content }}
-{% elseif getCoreSetting('image_fallback.teaser') %}
-  {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
 {% else %}
-    {{ "Missing image" }}
+    Missing image
 {% endif %}

--- a/templates/paragraphs/paragraph--gallery-item--gallery-modal-media.html.twig
+++ b/templates/paragraphs/paragraph--gallery-item--gallery-modal-media.html.twig
@@ -1,1 +1,7 @@
-{{ content }}
+{% if (content.field_media.0) %}
+  {{ content }}
+{% elseif getCoreSetting('image_fallback.teaser') %}
+  {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
+{% else %}
+    {{ "Missing image" }}
+{% endif %}

--- a/templates/paragraphs/paragraph--gallery-item--gallery-modal-media.html.twig
+++ b/templates/paragraphs/paragraph--gallery-item--gallery-modal-media.html.twig
@@ -1,5 +1,1 @@
-{% if (content.field_media.0) %}
-  {{ content }}
-{% else %}
-    Missing image
-{% endif %}
+{{ content }}


### PR DESCRIPTION
## [YSP-375: TwigTweak errors when removing media used in gallery](https://yaleits.atlassian.net/browse/YSP-375)

When troubleshooting a different issue, we found an issue where when an image that's used in a gallery is deleted, it resulted in a page error from TwigTweak.

This checks against this deletion and conveys to the user that the image is missing should it be deleted.

Work was also done in [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/344)

### Description of work
- Add guard against loading a media that does not exist
- If the media does not exist, render component library's image with empty params for "Missing image" message.

### Functional testing steps:
- [x] [Multidev available for testing](https://github.com/yalesites-org/yalesites-project/pull/594)
- [x] Create a gallery, including multiple images (make note of the images used)
- [x] Go to media gallery and delete one or more of those images
- [x] Return to the page with the gallery
- [x] Verify that the page loads and that in the place of the image, it displays "Missing image"
- [x] Go into site settings and add a fallback image
- [x] Verify when you return to the gallery, it now shows the fallback image
- [ ] Note: Clicking on it will yield no image
OR
- [ ] See it in action with [a gallery showing off a deleted item](https://pr-594-yalesites-platform.pantheonsite.io/daves-gallery-test)