### PR TITLE
YSP-301 Card collections without images

### DIFF
--- a/templates/node/node--event--text-card.html.twig
+++ b/templates/node/node--event--text-card.html.twig
@@ -1,0 +1,28 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set date__formatted %}
+  {% include "@atoms/date-time/yds-date-time.twig" with {
+    date_time__start: content.field_event_date.0.start_time['#markup'],
+  } %}
+{% endset %}
+
+{% if content.field_event_type %}
+  {% set reference_card__overline -%}
+    {% include "@molecules/cards/reference-card/event/_yds-event-format.twig" with {
+      format: content.field_event_type,
+    } %}
+  {%- endset %}
+{% endif %}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__heading: heading,
+  reference_card__subheading: date__formatted,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image: 'false',
+} %}
+{% endembed %}

--- a/templates/node/node--page--text-card.html.twig
+++ b/templates/node/node--page--text-card.html.twig
@@ -1,13 +1,12 @@
-{{ attach_library('atomic/reference-card') }}
+{{ attach_library('atomic/custom-card') }}
 
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
-{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
-  reference_card__heading: heading,
-  reference_card__subheading: date__formatted,
-  reference_card__url: url,
-  reference_card__snippet: content.field_teaser_text,
-  reference_card__image: 'false',
+{% embed "@molecules/cards/custom-card/yds-custom-card.twig" with {
+  custom_card__heading: heading,
+  custom_card__snippet: content.field_teaser_text,
+  custom_card__url: url,
+  custom_card__image: 'false',
 } %}
 {% endembed %}

--- a/templates/node/node--page--text-card.html.twig
+++ b/templates/node/node--page--text-card.html.twig
@@ -1,0 +1,13 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__heading: heading,
+  reference_card__subheading: date__formatted,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image: 'false',
+} %}
+{% endembed %}

--- a/templates/node/node--post--text-card.html.twig
+++ b/templates/node/node--post--text-card.html.twig
@@ -1,0 +1,20 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set date__formatted %}
+  {% include "@atoms/date-time/yds-date-time.twig" with {
+    date_time__start: date_formatted,
+    date_time__format: 'date',
+  } %}
+{% endset %}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__overline: date__formatted,
+  reference_card__heading: heading,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image: 'false',
+} %}
+{% endembed %}

--- a/templates/node/node--profile--text-card.html.twig
+++ b/templates/node/node--profile--text-card.html.twig
@@ -1,0 +1,13 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__heading: heading,
+  reference_card__subheading: content.field_position,
+  reference_card__url: url,
+  reference_card__snippet: content.field_subtitle,
+  reference_card__image: 'false',
+} %}
+{% endembed %}


### PR DESCRIPTION
## [YSP-301: Card collections without images](https://yaleits.atlassian.net/browse/YSP-301)

### Description of work
- Adds templates for the text_card view mode for all content types.

### Functional testing steps:
- [ ] Verify text cards look as expected - identical to visual cards but with no image.

Related to: https://github.com/yalesites-org/yalesites-project/pull/600
