### PR TITLE
YSP-366: Card display mode spacing between heading, content, and image

### DIFF
--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -6,7 +6,7 @@
   } %}
 {% endset %}
 
-{% if content.field_event_type %}
+{% if content.field_event_type.0 %}
   {% set reference_card__overline -%}
     {% include "@molecules/cards/reference-card/event/_yds-event-format.twig" with {
       format: content.field_event_type,


### PR DESCRIPTION
## [YSP-366: Card display mode spacing between heading, content, and image](https://yaleits.atlassian.net/browse/YSP-366)

### Description of work
- Adds conditional logic to `reference__card__overline` in Atomic template: 
- Adds `bottom-margin` to `__image` s in card grid to create more space between the image and the heading

### Testing Link(s)
- [ ] Test here: https://github.com/yalesites-org/component-library-twig/pull/342


