### PR TITLE
YSP-415: Add media text spinning

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -168,3 +168,9 @@ foreground. This causes contrast issues.  */
 html:not(.gin--dark-mode) #drupal-off-canvas:not(.drupal-off-canvas-reset).ui-dialog-content div:not([data-drupal-ck-style-fence] *), #drupal-off-canvas-wrapper .ui-dialog-content div:not([data-drupal-ck-style-fence] *) {
   color: var(--color-basic-white);
 }
+
+/* GinLB has a spinning animation of text that we didn't care for. */
+#drupal-off-canvas-wrapper .ajax-progress-throbber {
+  animation: none;
+  display: inline;
+}

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -1,4 +1,3 @@
-
 :root {
   --gin-font: Mallory, sans-serif;
   --gin-font-size-h1: 1.75rem;
@@ -73,17 +72,16 @@
 }
 
 @media only screen and (min-width: 2200px) {
-  .yds-two-column .layout-builder-block.contextual-region .contextual  {
+  .yds-two-column .layout-builder-block.contextual-region .contextual {
     left: -1vw;
   }
 }
 
 @media only screen and (min-width: 2500px) {
-  .yds-two-column .layout-builder-block.contextual-region .contextual  {
+  .yds-two-column .layout-builder-block.contextual-region .contextual {
     left: -1vw;
   }
 }
-
 
 /* add min-height so that smaller (in height) components are more easily
 // able to be interacted with - e.g. `divider`
@@ -117,7 +115,7 @@
 /*
 // Autocomplete styles (linkit)
 */
-.ui-autocomplete .ui-menu-item-wrapper:focus, 
+.ui-autocomplete .ui-menu-item-wrapper:focus,
 .ui-autocomplete .ui-menu-item-wrapper:hover {
   background-color: var(--gin-color-primary);
   color: var(--gin-bg-layer3);
@@ -165,7 +163,12 @@
 
 /* In light mode, gin is displaying a mustard background with a black 
 foreground. This causes contrast issues.  */
-html:not(.gin--dark-mode) #drupal-off-canvas:not(.drupal-off-canvas-reset).ui-dialog-content div:not([data-drupal-ck-style-fence] *), #drupal-off-canvas-wrapper .ui-dialog-content div:not([data-drupal-ck-style-fence] *) {
+html:not(.gin--dark-mode)
+  #drupal-off-canvas:not(.drupal-off-canvas-reset).ui-dialog-content
+  div:not([data-drupal-ck-style-fence] *),
+#drupal-off-canvas-wrapper
+  .ui-dialog-content
+  div:not([data-drupal-ck-style-fence] *) {
   color: var(--color-basic-white);
 }
 

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -180,7 +180,19 @@ html:not(.gin--dark-mode)
  * the message being displayed to the user.  This ensures that the z-index is
  * respected such that the message will show and the buttons will not be shown
  * during the throbber.
+ *
+ * We then do the same for the ui-dialog version since it also was clipping the
+ * text with link icons.
  */
+.ui-dialog .ajax-progress,
+.ui-dialog .ajax-progress-throbber {
+  background-color: var(--gin-bg-layer) !important;
+  border-radius: unset !important;
+  display: block;
+  height: var(--spacing-component-gutter);
+  z-index: 10;
+}
+
 #drupal-off-canvas-wrapper .ajax-progress,
 #drupal-off-canvas-wrapper .ajax-progress-throbber {
   animation: none;

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -172,13 +172,27 @@ html:not(.gin--dark-mode)
   color: var(--color-basic-white);
 }
 
-/* GinLB has a spinning animation of text that we didn't care for. */
+/*
+ * GinLB has a spinning text that we do not want in our system, so we disabled
+* the animation of the throbber wrapper.
+ *
+ * By attempting to hide this, the delete and edit links were appearing above
+ * the message being displayed to the user.  This ensures that the z-index is
+ * respected such that the message will show and the buttons will not be shown
+ * during the throbber.
+ */
+#drupal-off-canvas-wrapper .ajax-progress,
 #drupal-off-canvas-wrapper .ajax-progress-throbber {
   animation: none;
-  display: inline;
+  background-color: var(--gin-bg-layer) !important;
+
+  /* For some reason the throbber container had a border-radius? */
+  border-radius: unset;
+  display: block;
+  height: 100%;
   z-index: 10;
 }
 
-.ajax-progress-throbber .message {
-  display: block;
+.ajax-progress-throbber::before {
+  right: 0;
 }

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -176,4 +176,9 @@ html:not(.gin--dark-mode)
 #drupal-off-canvas-wrapper .ajax-progress-throbber {
   animation: none;
   display: inline;
+  z-index: 10;
+}
+
+.ajax-progress-throbber .message {
+  display: block;
 }

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -174,7 +174,7 @@ html:not(.gin--dark-mode)
 
 /*
  * GinLB has a spinning text that we do not want in our system, so we disabled
-* the animation of the throbber wrapper.
+ * the animation of the throbber wrapper.
  *
  * By attempting to hide this, the delete and edit links were appearing above
  * the message being displayed to the user.  This ensures that the z-index is
@@ -187,8 +187,15 @@ html:not(.gin--dark-mode)
 .ui-dialog .ajax-progress,
 .ui-dialog .ajax-progress-throbber {
   background-color: var(--gin-bg-layer) !important;
+
+  /* For some reason the throbber container had a border-radius? */
   border-radius: unset !important;
   display: block;
+
+  /*
+   * Setting a height of 100 in this case will cover the image.  So we set a
+   * lower height that will still cover the links
+   */
   height: var(--spacing-component-gutter);
   z-index: 10;
 }


### PR DESCRIPTION
## [YSP-415: Add media text spinning](https://yaleits.atlassian.net/browse/YSP-415)

### Description of work
- Disables animation on "throbber"
- Displays the throbber in front of the edit/delete links that usually appear on the image

### Functional testing steps:
- [ ] Visit [multidev](https://pr-606-yalesites-platform.pantheonsite.io/cas) and log in
- [ ] Edit/add a new block that has a media image attached
- [ ] Clicking "Add media" should result in a message stating "Opening media library." with a small spinner (depending on how long it takes to load)
<img width="433" alt="Screenshot 2024-03-20 at 9 58 33 AM" src="https://github.com/yalesites-org/atomic/assets/128765777/e761c555-5454-494c-abc4-a365b78532a7">

- [ ] Removing media should also clearly display the removing message
<img width="420" alt="Screenshot 2024-03-20 at 9 58 03 AM" src="https://github.com/yalesites-org/atomic/assets/128765777/74039578-1975-4cad-a8bc-7350570b16c6">

- [ ] Attempt to add a new block with an image; ensure that the text displayed when trying to add media and removing the media from the block also displays the messages without the links being in the way.
![Screenshot 2024-03-20 at 10 27 40 AM](https://github.com/yalesites-org/atomic/assets/128765777/57327697-41f8-4564-ac2a-71bd6c6e308d)
