### PR TITLE
YSP-428 Fix double-encoded document links

### DIFF
--- a/templates/link/link-formatter-link-separate.html.twig
+++ b/templates/link/link-formatter-link-separate.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Default theme implementation of a link with separate title and URL elements.
+ *
+ * Available variables:
+ * - link: The link that has already been formatted by l().
+ * - title: (optional) A descriptive or alternate title for the link, which may
+ *   be different than the actual link text.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_link_formatter_link_separate()
+ *
+ * @ingroup themeable
+ */
+#}
+{% apply spaceless %}
+  {{ title }}
+  {{ link|url_decode }}
+{% endapply %}


### PR DESCRIPTION
## [YSP-428: Fix double-encoded document links](https://yaleits.atlassian.net/browse/YSP-428)

### Description of work
- Links are double-encoded which breaks the link if there is a space in the file name.

### Functional testing steps:
- [ ] Add a file that contains a space (or more than one) in the file name
- [ ] Add a link to that file in a linkit field, like Spotlight - landscape
- [ ] Verify that the link address does not contain %2025 where the space was and that when you click on it, the document opens