### PR TITLE
YSP-422: AX headings aren't adapting to light/dark mode

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -15,7 +15,9 @@
 }
 
 /* embed headers need gin's color text to look good in dark mode */
-html.gin--dark-mode #ajax-embed-instructions {
+html.gin--dark-mode #ajax-embed-instructions,
+/* Any configure block should be using this as well */
+html.gin--dark-mode form.layout-builder-configure-block.glb-form {
   --color-heading: var(--gin-color-text);
 }
 

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -14,6 +14,11 @@
   font-weight: 600;
 }
 
+/* embed headers need gin's color text to look good in dark mode */
+html.gin--dark-mode #ajax-embed-instructions {
+  --color-heading: var(--gin-color-text);
+}
+
 /* Make the secondary toolbar fixes */
 .gin-secondary-toolbar--frontend {
   position: fixed;

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -174,7 +174,7 @@ html:not(.gin--dark-mode)
 #drupal-off-canvas-wrapper
   .ui-dialog-content
   div:not([data-drupal-ck-style-fence] *) {
-  color: var(--color-basic-white);
+  color: var(--gin-color-text);
 }
 
 /*

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -168,11 +168,11 @@ html.gin--dark-mode #ajax-embed-instructions {
 
 /* In light mode, gin is displaying a mustard background with a black 
 foreground. This causes contrast issues.  */
-html:not(.gin--dark-mode)
-  #drupal-off-canvas:not(.drupal-off-canvas-reset).ui-dialog-content
-  div:not([data-drupal-ck-style-fence] *),
 #drupal-off-canvas-wrapper
   .ui-dialog-content
+  div:not([data-drupal-ck-style-fence] *),
+html:not(.gin--dark-mode)
+  #drupal-off-canvas:not(.drupal-off-canvas-reset).ui-dialog-content
   div:not([data-drupal-ck-style-fence] *) {
   color: var(--gin-color-text);
 }


### PR DESCRIPTION
## [YSP-422: AX headings aren't adapting to light/dark mode](https://yaleits.atlassian.net/browse/YSP-422)
## [YSP-435: Pre-built form configuration contrast issue in dark mode](https://yaleits.atlassian.net/browse/YSP-435)

### Description of work
- Change CSS to use `--gin-color-text` where found.

### Functional testing steps:
- [x] Visit [multidev](https://pr-614-yalesites-platform.pantheonsite.io/) for testing
#### Embeds
- [x] Attempt to add an embed block and click the instructions
- [x] Ensure they are now legible
#### Move section
- [x] Disable `preview content` in the `Edit layout for` page
- [x] Click on a block as if you're going to edit but instead go to `Move`
- [x] Ensure you can see all names of the blocks without issue
#### Custom card blocks
- [x] Add a custom card block, making sure to add multiple cards
- [x] Ensure that "Custom card" is visible, as well as any headings while creating new cards
#### Pre-built form
- [x] Attempt to add a pre built form block
- [x] While in the configuration of it, select "Scheduled"
- [x] Ensure you can properly see the text that appears