### PR TITLE
YSP-436: Reference cards: Backend and content tools

### DIFF
--- a/templates/block/layout-builder/block--inline-block--reference-card.html.twig
+++ b/templates/block/layout-builder/block--inline-block--reference-card.html.twig
@@ -1,0 +1,18 @@
+{% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
+
+{% block content %}
+
+  {% embed "@organisms/card-collection/yds-card-collection.twig" with {
+    card_collection__source_type: 'events',
+    card_collection__type: 'single',
+    card_collection__width: 'site',
+    card_collection__featured: 'true',
+    animate__item: 'enabled',
+  } %}
+    {% block card_collection__cards %}
+      {{ content.field_content_ref }}
+    {% endblock %}
+  {% endembed %}
+
+{% endblock %}
+

--- a/templates/block/layout-builder/block--inline-block--reference-card.html.twig
+++ b/templates/block/layout-builder/block--inline-block--reference-card.html.twig
@@ -2,11 +2,14 @@
 
 {% block content %}
 
+  {% set style = content.field_style_variation[0]['#markup'] == 'featured' ? 'true' : 'false' %}
+  {% set type = content.field_content_ref[0]['#node'].getType() %}
+
   {% embed "@organisms/card-collection/yds-card-collection.twig" with {
-    card_collection__source_type: 'events',
+    card_collection__source_type: type,
     card_collection__type: 'single',
     card_collection__width: 'site',
-    card_collection__featured: 'true',
+    card_collection__featured: style,
     animate__item: 'enabled',
   } %}
     {% block card_collection__cards %}

--- a/templates/field/field--block-content--field-content-ref--reference-card.html.twig
+++ b/templates/field/field--block-content--field-content-ref--reference-card.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/templates/node/node--event--single.html.twig
+++ b/templates/node/node--event--single.html.twig
@@ -1,0 +1,37 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set date__formatted %}
+  {% include "@atoms/date-time/yds-date-time.twig" with {
+    date_time__start: content.field_event_date.0.start_time['#markup'],
+  } %}
+{% endset %}
+
+{% if content.field_event_type.0 %}
+  {% set reference_card__overline -%}
+    {% include "@molecules/cards/reference-card/event/_yds-event-format.twig" with {
+      format: content.field_event_type,
+    } %}
+  {%- endset %}
+{% endif %}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__heading: heading,
+  reference_card__subheading: date__formatted,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image: 'true',
+} %}
+  {% block reference_card__image %}
+
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
+    {% endif %}
+
+  {% endblock %}
+{% endembed %}

--- a/templates/node/node--post--single.html.twig
+++ b/templates/node/node--post--single.html.twig
@@ -1,0 +1,28 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set date__formatted %}
+  {% include "@atoms/date-time/yds-date-time.twig" with {
+    date_time__start: date_formatted,
+    date_time__format: 'date',
+  } %}
+{% endset %}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__overline: date__formatted,
+  reference_card__heading: heading,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+} %}
+  {% block reference_card__image %}
+
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
+    {% endif %}
+
+  {% endblock %}
+{% endembed %}

--- a/templates/node/node--profile--single.html.twig
+++ b/templates/node/node--profile--single.html.twig
@@ -1,0 +1,23 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__heading: heading,
+  reference_card__subheading: content.field_position,
+  reference_card__url: url,
+  reference_card__snippet: content.field_subtitle,
+  reference_card__image: 'true',
+} %}
+  {% block reference_card__image %}
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif content.field_media[0] %}
+      {{ content.field_media }}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'profile_directory_card_1_1_') }}
+    {% endif %}
+
+  {% endblock %}
+{% endembed %}


### PR DESCRIPTION
## [YSP-436: Reference cards: Backend and content tools](https://yaleits.atlassian.net/browse/YSP-436)

**Relates to**

## [YSP-308: Reference cards: Create components from Designs](https://yaleits.atlassian.net/browse/YSP-308)

### Description of work
- Adds templates that connect the BE to the FE for the reference card component
- Related to [this PR](https://github.com/yalesites-org/yalesites-project/pull/616) in Yalesites Project and [this PR](https://github.com/yalesites-org/component-library-twig/pull/345) in the component library
- 

### Functional testing steps:
- [ ] see [this PR](https://github.com/yalesites-org/yalesites-project/pull/616)
