### PR TITLE
YSP-430: Canvas user need to allow two call to actions in banner

### DIFF
--- a/templates/block/layout-builder/block--inline-block--cta-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--cta-banner.html.twig
@@ -8,6 +8,8 @@
     banner__snippet: content.field_text,
     banner__link__content: content.field_link.0['#title'],
     banner__link__url: content.field_link.0['#url_title'],
+    banner__link__content_two: content.field_link_two.0['#title'],
+    banner__link__url_two: content.field_link_two.0['#url_title'],
     banner__content__background: content.field_style_color.0['#markup'],
     banner__content__layout: content.field_style_position.0['#markup'],
     banner__width: 'site',

--- a/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
+++ b/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
@@ -8,6 +8,8 @@
     grand_hero__snippet: content.field_text.0,
     grand_hero__link__content: content.field_link.0['#title'],
     grand_hero__link__url: content.field_link.0['#url_title'],
+    grand_hero__link__content_two: content.field_link_two.0['#title'],
+    grand_hero__link__url_two: content.field_link_two.0['#url_title'],
     grand_hero__content__background: content.field_style_color.0['#markup'],
     grand_hero__overlay_variation: content.field_style_position.0['#markup'],
     grand_hero__size: content.field_style_variation.0['#markup'],


### PR DESCRIPTION
## [YSP-430: Canvas user need to allow two call to actions in banner](https://yaleits.atlassian.net/browse/YSP-430)

### Description of work
- Adds optional second link field for cta banner and grand hero banner
- Adds a button-group wrapping div to preserve the existing space between elements
- Adds wiring for optional second link

### Functional Review Steps
- [ ] Test in main PR: https://github.com/yalesites-org/yalesites-project/pull/621