### PR TITLE
YSP-399: Localist: Embedding widgets

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -5,6 +5,7 @@ global:
       node_modules/@yalesites-org/component-library-twig/dist/style.css: {}
       components/_settings/_config.css: {}
       css/admin-theme.css: {}
+      css/localist.css: {}
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/menu/menu-toggle/yds-menu-toggle.js:
       {}

--- a/css/localist.css
+++ b/css/localist.css
@@ -1,0 +1,19 @@
+.localist_widget_container .action_button a {
+  /* stylelint-disable hue-degree-notation, color-function-notation */
+
+  /* Color taken from inline styles brought in with localist.
+   * This matches the background color that is the button.
+   * Stylelint placed to exactly match what is coming from localist.
+   */
+  --color-text-shadow: hsl(213, 66%, 45%);
+  /* stylelint-enable hue-degree-notation, color-function-notation */
+}
+
+/* Use our text decoration for the title and entity source links.
+ * important was unfortunately needed due to the page inline style taking
+ * precedence over this file.
+ */
+.localist_widget_container li a:hover,
+.localist_widget_container .lw_event_item_title a:hover {
+  text-decoration: none !important;
+}

--- a/css/localist.css
+++ b/css/localist.css
@@ -13,6 +13,7 @@
  * important was unfortunately needed due to the page inline style taking
  * precedence over this file.
  */
+.localist-widget .event__list__content_event-title:hover,
 .localist_widget_container li a:hover,
 .localist_widget_container .lw_event_item_title a:hover {
   text-decoration: none !important;

--- a/css/localist.css
+++ b/css/localist.css
@@ -17,3 +17,14 @@
 .localist_widget_container .lw_event_item_title a:hover {
   text-decoration: none !important;
 }
+
+.localist_widget_container .action_button a:hover {
+  /* stylelint-disable hue-degree-notation, color-function-notation */
+
+  /* Color taken from inline styles brought in with localist.
+   * This matches the background color that is the button when hovered.
+   * Stylelint placed to exactly match what is coming from localist.
+   */
+  --color-text-shadow: hsl(0, 0%, 25%);
+  /* stylelint-enable hue-degree-notation, color-function-notation */
+}


### PR DESCRIPTION
## [YSP-399: Localist: Embedding widgets](https://yaleits.atlassian.net/browse/YSP-399)

The shadow set for the button was set to the text color instead of what the current background color was, resulting in a hard to read button text.  Due to localist defining the color of the button, we copied this value from them in order to make it look correct.

The other links have our animation effect, however localist was defining a hover line to appear, which made this look awful.  This forces the links to not underline and to instead use our underline effect.

### Description of work
- Add `localist.css` file to break up concerns
- Change shadow color to match background sent from localist styling
- Force override of localist hover underline so we can have our animations

### Functional testing steps:
- [ ] Visit [Marc's Localist Widget Page](https://pr-630-yalesites-platform.pantheonsite.io/testing-localist-widgets)
- [ ] Verify that links function as intended and look good