### PR TITLE
YSP-458: Editorial Workflow: Display improvements to right panel

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -161,6 +161,10 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
   color: var(--menu-link-color) !important;
 }
 
+.gin--dark-mode #drupal-off-canvas-wrapper a:not(.button) {
+  color: var(--color-blue-light) !important;
+}
+
 /*
 Moderation sidebar
 */
@@ -181,6 +185,10 @@ Moderation sidebar
 
 .entity-moderation-form input[type="submit"] {
   margin-bottom: 0;
+}
+
+.moderation-sidebar-container .moderation-sidebar-revision-log {
+  border: 1px solid var(--color-text) !important;
 }
 
 /*

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -132,6 +132,8 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
 // Offcanvas toolbar styles
 */
 #drupal-off-canvas-wrapper {
+  --off-canvas-button-background-color: #555;
+
   color: var(--gin-color-text) !important;
   background-color: var(--gin-bg-layer) !important;
   font-family: var(--gin-font);

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -174,7 +174,7 @@ Moderation sidebar
   margin: 1.5rem 0 !important;
 }
 
-.moderation-sidebar-container .moderation-sidebar-revision-item:last-child {
+.moderation-sidebar-container .moderation-sidebar-revision-item:last-of-type {
   border-bottom: 0 !important;
 }
 

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -134,6 +134,7 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
 #drupal-off-canvas-wrapper {
   color: var(--gin-color-text) !important;
   background-color: var(--gin-bg-layer) !important;
+  font-family: var(--gin-font);
 }
 
 #drupal-off-canvas-wrapper .ui-dialog-titlebar {
@@ -141,7 +142,48 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
   color: var(--gin-color-text) !important;
 }
 
-/* 
+#drupal-off-canvas-wrapper .button--primary {
+  background-color: var(--color-blue-yale) !important;
+}
+
+#drupal-off-canvas-wrapper .button--primary:hover,
+#drupal-off-canvas-wrapper .button--primary:focus,
+#drupal-off-canvas-wrapper .button--primary:active {
+  color: var(--off-canvas-primary-button-text-color) !important;
+  background-color: var(--color-blue-royal) !important;
+}
+
+#drupal-off-canvas-wrapper .button--danger:hover {
+  background-color: var(--gin-color-danger) !important;
+}
+
+#drupal-off-canvas-wrapper a:not(.button) {
+  color: var(--menu-link-color) !important;
+}
+
+/*
+Moderation sidebar
+*/
+
+.moderation-sidebar-container .moderation-sidebar-revision-item {
+  border-bottom: 1px solid var(--color-text) !important;
+  margin: 1.5rem 0 !important;
+}
+
+.moderation-sidebar-container .moderation-sidebar-revision-item:last-child {
+  border-bottom: 0 !important;
+}
+
+.entity-moderation-form {
+  padding: 1rem;
+  margin: 1rem auto;
+}
+
+.entity-moderation-form input[type="submit"] {
+  margin-bottom: 0;
+}
+
+/*
 // Image crop vertical tabs override
 */
 
@@ -168,7 +210,7 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
   color: var(--gin-color-text) !important;
 }
 
-/* In light mode, gin is displaying a mustard background with a black 
+/* In light mode, gin is displaying a mustard background with a black
 foreground. This causes contrast issues.  */
 #drupal-off-canvas-wrapper
   .ui-dialog-content


### PR DESCRIPTION
## [YSP-458: Editorial Workflow: Display improvements to right panel](https://yaleits.atlassian.net/browse/YSP-458)

### Description of work
- Adds styling for the new moderation sidebar
- Adds styling for the moderation form when nodes are in a draft state

### Functional testing steps:
- [ ] Test over in main repo: https://github.com/yalesites-org/yalesites-project/pull/637
