### PR TITLE
Update all actions to latest and run setup-node with node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.13
+          node-version: 20
       - name: Install
         run: npm ci
         env:
           YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
       - name: Commit Compiled Component Library
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           add: "node_modules/@yalesites-org/component-library-twig -f"
           message: "build: commit compiled component library"


### PR DESCRIPTION
### Description of work
- Updates actions/checkout, actions/setup-node, EndBug/add-and-commit to latest versions
- Since node 16 is now deprecated in github actions, run setup-node with node 20
