### PR TITLE
Reset main branch when creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
-        run: npm run semantic-release
+        run: npx semantic-release
       - name: Remove Compiled Component Library
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Commit Compiled Component Library
         uses: EndBug/add-and-commit@v9
         with:
+          author_name: github-actions[bot]
+          author_email: github-actions[bot]@users.noreply.github.com
           add: "node_modules/@yalesites-org/component-library-twig -f"
           message: "build: commit compiled component library"
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YALESITES_BUILD_TOKEN: ${{ secrets.YALESITES_BUILD_TOKEN }}
         run: npx semantic-release
-      - name: Remove Compiled Component Library
-        uses: EndBug/add-and-commit@v7
-        with:
-          remove: "--cached -r node_modules"
-          message: "build: removed compiled component library from git"
+      - name: Reset branch to prior commit
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git reset --hard $GITHUB_SHA
+          git push --force

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "husky:pre-commit": "lint-staged",
     "prepare": "husky install",
     "prettier": "prettier ./ --ignore-unknown --list-different",
-    "semantic-release": "semantic-release",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description of work
`main` and `develop` branches are out of sync due to the changes committed to `main` during releases. This PR proposes these changes:

- Instead of making 2 commits - one to add the component library, and one to delete it - do a `git reset` to `$GITHUB_SHA`, which is the SHA that triggered the build, instead of making a second commit. This prevents main from getting out of sync just to package the build assets
- Switch the commit author to Github Actions bot
- Unrelated cleanup: remove the custom `npm semantic-release` command and run semantic-release with npx