### PR TITLE
YSP-554 - Hamburger icon shows on empty menu

### DIFF
--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -5,6 +5,13 @@
   {% set site_header__site_name_is_image = getHeaderSetting('site_name_image') %}
 {% endif %}
 
+{# set primary and utility nave variables equal to their drupal elements #}
+{# this is necessary to pass the truthiness of the elements to the site-header organism #}
+{# which will set {% set site_header__hamburger = 'yes' %} #}
+{# and render the hamburger icon if the primary nav exists or the ulitity nav exists #}
+{% set primary_nav__items = elements.main_navigation.content['#items'] %}
+{% set utility_nav__items = elements.utility_navigation.content['#items'] %}
+
 {% embed "@organisms/site-header/yds-site-header.twig" with {
   site_name: site_name,
   site_header__border_thickness: '8',


### PR DESCRIPTION
## [YSP-554: Hamburger icon shows on empty menu](https://fourkitchens.clickup.com/t/86a3m6kkp)

### Description of work
- Hide the hamburger icon when all the menus are empty.
- Adds `site_header__hamburger` as a variable conditionally set by either `utility_nav__items` or `primary_nav__items` having items within them
- In Atomic, `utility_nav__items` or `primary_nav__items` are set to
 ```
 {% set primary_nav__items = elements.main_navigation.content['#items'] %}
 {% set utility_nav__items = elements.utility_navigation.content['#items'] %}
 ``` 
 
### Functional Review Steps
- [ ] Test in Drupal in component-library PR: https://github.com/yalesites-org/component-library-twig/pull/373
