### PR TITLE
YSP-487: Add JWPlayer Embed

### DIFF
--- a/templates/ys_embed/embed_wrapper.html.twig
+++ b/templates/ys_embed/embed_wrapper.html.twig
@@ -1,6 +1,7 @@
 {% set embed_wrapper__embed_type = displayAttributes['embedType']|default('unknown') %}
 {% set embed_wrapper__width = displayAttributes['width']|default('site') %}
 {% set embed_wrapper__height = displayAttributes['height']|default('100%') %}
+{% set embed_wrapper__allowfullscreen = displayAttributes['allowfullscreen'] == TRUE ? 'true' : 'false' %}
 
 {% if displayAttributes['isIframe'] %}
     <div data-embedded-components>
@@ -9,6 +10,7 @@
             embed__title: title,
             embed__width: embed_wrapper__width,
             embed__type: embed_wrapper__embed_type,
+	    embed__allowfullscreen: embed_wrapper__allowfullscreen,
         } %}
         {% endembed %}
     </div>


### PR DESCRIPTION
## [YSP-487: Add JWPlayer Embed](https://yaleits.atlassian.net/browse/YSP-487)

### Other work related to this
- [YaleSites Project: PR #676](https://github.com/yalesites-org/yalesites-project/pull/676)
- [Component Library Twig: PR #376](https://github.com/yalesites-org/component-library-twig/pull/376)

### Description of work
- Wires up allowfullscreen to embeds

### Functional testing steps:
- [ ] Testable in YaleSites multidev