### PR TITLE
fix(semrel): update version to help semrel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yalesites-org/atomic",
-  "version": "1.31.0",
+  "version": "1.32.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yalesites-org/atomic",
-      "version": "1.31.0",
+      "version": "1.32.1",
       "bundleDependencies": [
         "@yalesites-org/component-library-twig"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yalesites-org/atomic",
-  "version": "1.31.0",
+  "version": "1.32.1",
   "description": "Atomic theme for YaleSites projects.",
   "files": [
     "components",


### PR DESCRIPTION
This is an attempt to make semantic release not reuse the same version tag it had before.  I'm hoping I just forgot to perform this step.