### PR TITLE
YSP-581: Mobile hamburger menu not showing up

### DIFF
--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -9,8 +9,8 @@
 {# this is necessary to pass the truthiness of the elements to the site-header organism #}
 {# which will set {% set site_header__hamburger = 'yes' %} #}
 {# and render the hamburger icon if the primary nav exists or the ulitity nav exists #}
-{% set primary_nav__items = elements.main_navigation.content['#items'] %}
-{% set utility_nav__items = elements.utility_navigation.content['#items'] %}
+{% set primary_nav__items = elements.main_navigation.content['#items'] is not empty %}
+{% set utility_nav__items = elements.utility_navigation.content['#items'] is not empty %}
 
 {% embed "@organisms/site-header/yds-site-header.twig" with {
   site_name: site_name,


### PR DESCRIPTION
## [YSP-581: Mobile hamburger menu not showing up](https://yaleits.atlassian.net/browse/YSP-581)

### Description of work
- Updates `primary_nav__items` and `utility_nav__items` checks to `is not empty`
- I'm thinking that maybe the check for either `primary` or `utility` navs was

### Functional testing steps:
- [ ] Pull down branch locally
- [ ] Test with https://github.com/yalesites-org/component-library-twig/pull/387
- [ ] Clear cache
- [ ] To test locally, open the `region--header.html.twig` file edited in this PR
- [ ] In between the two `set` variable declarations and the `{% embed` add: 
```
{% set break = '<br>' %}
{{break|raw}}
{{'------------'}}
{{break|raw}}
{{break|raw}}
{{break|raw}}

{{'Primary'}}
{{dd(primary_nav__items)}}

{{break|raw}}

{{'Utility'}}
{{dd(utility_nav__items)}}

{{break|raw}}

{{'Primary'}}
{{ dd(elements.main_navigation.content['#items'])}}

{{break|raw}}

{{'Utility'}}
{{dd(elements.utility_navigation.content['#items'])}}
```
- The 
- [ ] If you clear cache and navigate to https://yalesites-platform.lndo.site/
- [ ] You should see something like this with the `dd` output

<img width="769" alt="Screenshot 2024-07-18 at 15 04 40" src="https://github.com/user-attachments/assets/f21b1182-4cca-475c-a965-ef330a7b9517">

---
- [ ] If you edit the main menu items and uncheck all the top-level items: https://yalesites-platform.lndo.site/admin/structure/menu/manage/main
- [ ] Save and refresh the frontend. You should see this: 

<img width="739" alt="Screenshot 2024-07-18 at 14 56 55" src="https://github.com/user-attachments/assets/77fba96d-0dba-4de3-9e11-761af7519e67">

---

- [ ] If you edit the utility nav menu items and uncheck all items: https://yalesites-platform.lndo.site/admin/structure/menu/manage/utility-navigation
- [ ] Save and refresh the frontend. You should see this: 

<img width="776" alt="Screenshot 2024-07-18 at 14 58 16" src="https://github.com/user-attachments/assets/3d7c6bd4-d572-4fda-b598-19b49ee79da3">

--- 
- [ ] If you go back and re-check the utility menu items: https://yalesites-platform.lndo.site/admin/structure/menu/manage/utility-navigation
- [ ] Save and refresh the frontend. You should see this: 

<img width="739" alt="Screenshot 2024-07-18 at 14 56 55" src="https://github.com/user-attachments/assets/37017ee6-5a15-4d1d-8db3-11390bdd9554">

---
- [ ] I'm not positive, but maybe the most recent issue, seen here: https://sas.yale.edu/ is the result of one or both menus returning `null`?
- [ ] I'm hoping that definitively checking for `true` or `false` will fix any issues.



