### PR TITLE
YSP-581: Mobile hamburger menu not showing up

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@
 A Drupal theme for the YaleSites platform
 
 # Contributing
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on contributing to this theme.

--- a/README.md
+++ b/README.md
@@ -3,5 +3,4 @@
 A Drupal theme for the YaleSites platform
 
 # Contributing
-
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on contributing to this theme.

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -20,6 +20,8 @@
   site_header__menu__variation: getHeaderSetting('header_variation'),
   site_header__nav_position: getHeaderSetting('nav_position'),
   drupal_utility_nav: elements.utility_navigation,
+  primary_nav__items: primary_nav__items,
+  utility_nav__items: utility_nav__items,
 } %}
   {% block site_header__primary_nav %}
     {{ elements.main_navigation }}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -5,13 +5,6 @@
   {% set site_header__site_name_is_image = getHeaderSetting('site_name_image') %}
 {% endif %}
 
-{# set primary and utility nave variables equal to their drupal elements #}
-{# this is necessary to pass the truthiness of the elements to the site-header organism #}
-{# which will set {% set site_header__hamburger = 'yes' %} #}
-{# and render the hamburger icon if the primary nav exists or the ulitity nav exists #}
-{% set primary_nav__items = elements.main_navigation.content['#items'] %}
-{% set utility_nav__items = elements.utility_navigation.content['#items'] %}
-
 {% embed "@organisms/site-header/yds-site-header.twig" with {
   site_name: site_name,
   site_header__border_thickness: '8',

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -13,8 +13,6 @@
   site_header__menu__variation: getHeaderSetting('header_variation'),
   site_header__nav_position: getHeaderSetting('nav_position'),
   drupal_utility_nav: elements.utility_navigation,
-  primary_nav__items: primary_nav__items,
-  utility_nav__items: utility_nav__items,
 } %}
   {% block site_header__primary_nav %}
     {{ elements.main_navigation }}


### PR DESCRIPTION
## [YSP-581: Mobile hamburger menu not showing up](https://yaleits.atlassian.net/browse/YSP-581)

More work done in [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/389) for this.

### Description of work
- Reverts the conditional logic to not display the hamburger

### Functional testing steps:
- [ ] Verify that every node you go to has a hamburger in the DOM

### Notes
- Remember that the real issue cannot be duplicated on multidevs or locally, but the reverted code ensures display in every case.