### PR TITLE
YSP-495: Site-wide branding for University groups

### DIFF
--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -19,6 +19,8 @@
   site_header__accent: getThemeSetting('header_accent'),
   site_header__menu__variation: getHeaderSetting('header_variation'),
   site_header__nav_position: getHeaderSetting('nav_position'),
+  site_header__branding_name: getHeaderSetting('site_wide_branding_name'),
+  site_header__branding_link: getHeaderSetting('site_wide_branding_link'),
   drupal_utility_nav: elements.utility_navigation,
 } %}
   {% block site_header__primary_nav %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -19,8 +19,8 @@
   site_header__accent: getThemeSetting('header_accent'),
   site_header__menu__variation: getHeaderSetting('header_variation'),
   site_header__nav_position: getHeaderSetting('nav_position'),
-  site_header__branding_name: getHeaderSetting('site_wide_branding_name'),
-  site_header__branding_link: getHeaderSetting('site_wide_branding_link'),
+  site_header__branding_name: getHeaderSetting('site_wide_branding_name')|default('Yale University'),
+  site_header__branding_link: getHeaderSetting('site_wide_branding_link')|default('https://www.yale.edu'),
   drupal_utility_nav: elements.utility_navigation,
 } %}
   {% block site_header__primary_nav %}


### PR DESCRIPTION
## [YSP-495: Site-wide branding for University groups](https://yaleits.atlassian.net/browse/YSP-495)

This allows the transfer of the branding name and URL settings to the rendering of the secondary header.  This enables a customization of the branding that is shown sitewide, along with the URL it links to.

[Yalesites Project](https://github.com/yalesites-org/yalesites-project/pull/711)
[Atomic](https://github.com/yalesites-org/atomic/pull/255)
[Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/391)

### Description of work
- Passes sitewide branding name and link URL to component library twig

### Functional testing steps:
- [ ] See Yalesites Project multidev testing