### PR TITLE
JAKALA: Spotlight cards enhancement

### DIFF
--- a/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
@@ -9,6 +9,8 @@
       content_spotlight_portrait__text: content.field_text,
       content_spotlight_portrait__link__content: content.field_link.0['#title'],
       content_spotlight_portrait__link__url: content.field_link.0['#url_title'],
+      content_spotlight_portrait__link_two__content: content.field_link_two.0['#title'],
+      content_spotlight_portrait__link_two__url: content.field_link_two.0['#url_title'],
       content_spotlight_portrait__style: content.field_style_variation.0['#markup'],
       content_spotlight_portrait__position: content.field_style_position.0['#markup'],
       content_spotlight_portrait__theme: content.field_style_color.0['#markup'],

--- a/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
@@ -9,6 +9,8 @@
     text_with_image__text: content.field_text,
     text_with_image__link__content: content.field_link.0['#title'],
     text_with_image__link__url: content.field_link.0['#url_title'],
+    text_with_image__link_two__content: content.field_link_two.0['#title'],
+    text_with_image__link_two__url: content.field_link_two.0['#url_title'],
     text_with_image__focus: content.field_style_variation.0['#markup'],
     text_with_image__position: content.field_style_position.0['#markup'],
     text_with_image__width: content.field_style_width.0['#markup'],

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -12,6 +12,8 @@
   site_header__accent: getThemeSetting('header_accent'),
   site_header__menu__variation: getHeaderSetting('header_variation'),
   site_header__nav_position: getHeaderSetting('nav_position'),
+  site_header__branding_name: getHeaderSetting('site_wide_branding_name')|default('Yale University'),
+  site_header__branding_link: getHeaderSetting('site_wide_branding_link')|default('https://www.yale.edu'),
   drupal_utility_nav: elements.utility_navigation,
 } %}
   {% block site_header__primary_nav %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -5,13 +5,6 @@
   {% set site_header__site_name_is_image = getHeaderSetting('site_name_image') %}
 {% endif %}
 
-{# set primary and utility nave variables equal to their drupal elements #}
-{# this is necessary to pass the truthiness of the elements to the site-header organism #}
-{# which will set {% set site_header__hamburger = 'yes' %} #}
-{# and render the hamburger icon if the primary nav exists or the ulitity nav exists #}
-{% set primary_nav__items = elements.main_navigation.content['#items'] %}
-{% set utility_nav__items = elements.utility_navigation.content['#items'] %}
-
 {% embed "@organisms/site-header/yds-site-header.twig" with {
   site_name: site_name,
   site_header__border_thickness: '8',


### PR DESCRIPTION
## JAKALA: Spotlight cards enhancement

Previously, "Spotlight Cards" supported only one Call-to-Action (CTA) link. This pull request enhances the functionality by allowing a second CTA link to be added and rendered on the cards.

### Description of work
- Add field_link_two data in the Content Spotlight block templates

### Functional testing steps:
- [ ] Add Content Spotlight - Portrait or Content Spotlight Landscape block
- [ ] Populate 'Secondary Link' field URL and Link Text 
- [ ] Ensure the 'Secondary Link' field is rendered per [design](https://www.figma.com/design/7dxhigoRGh80M0EOZ3wONc/Design?node-id=668-7301&t=NlFYLYBUqZi4on1r-0).

Related PRs:
- https://github.com/yalesites-org/yalesites-project/pull/729
- https://github.com/yalesites-org/component-library-twig/pull/396
