### PR TITLE
JAKALA: Add Content Type filter to Search Page

### DIFF
--- a/templates/form/ys-search-form.html.twig
+++ b/templates/form/ys-search-form.html.twig
@@ -1,7 +1,31 @@
 <form action="/search" method="get" class="search-form--page form--inline" id="page-search-form" accept-charset="UTF-8">
-  <div class="form-item form-item-keywords">
-    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value="" size="30" maxlength="128" class="form-text form-item__textfield">
+  <div class="form-item form-item--search form-item-keywords">
+    <label for="edit-keywords--page-search-form" class="form-item__label">
+      <span>{{ 'Search:'|t }}</span>
+      {% include "@atoms/images/icons/_yds-icon.twig" with {
+        icon__name: 'magnifying-glass',
+        icon__blockname: 'form-item',
+        icon__modifiers: ['search'],
+        icon__decorative: true,
+      } %}
+    </label>
+    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value=""
+           size="30" maxlength="128" class="form-text form-item__textfield">
   </div>
+  {% if show_content_type_filter %}
+    <div class="form-item">
+      <label for="edit-type--page-search-form" class="form-item__label">{{ 'Show:'|t }}</label>
+      <div class="form-item__dropdown">
+        <select data-drupal-selector="edit-type" id="edit-type--page-search-form" name="type"
+                class="form-select form-item__select">
+          <option value="all" selected="selected">{{'- All -'|t}}</option>
+          {% for key, value in content_type_list %}
+            <option value="{{ key }}">{{ value|capitalize }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endif %}
   <div class="form-actions form-wrapper" id="edit-actions--page-search-form">
     {% include '@atoms/controls/cta/yds-cta.twig' with {
       control__element: 'input',

--- a/templates/form/ys-search-form.html.twig
+++ b/templates/form/ys-search-form.html.twig
@@ -9,7 +9,7 @@
         icon__decorative: true,
       } %}
     </label>
-    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value=""
+    <input placeholder="Start new search" type="text" id="edit-keywords--page-search-form" name="keywords" value="{{ getQueryParam('keywords') }}"
            size="30" maxlength="128" class="form-text form-item__textfield">
   </div>
   {% if show_content_type_filter %}
@@ -20,7 +20,7 @@
                 class="form-select form-item__select">
           <option value="all" selected="selected">{{'- All -'|t}}</option>
           {% for key, value in content_type_list %}
-            <option value="{{ key }}">{{ value|capitalize }}</option>
+            <option value="{{ key }}" {% if key == getQueryParam('type') %}selected{% endif %}>{{ value|capitalize }}</option>
           {% endfor %}
         </select>
       </div>

--- a/templates/node/node--search-result.html.twig
+++ b/templates/node/node--search-result.html.twig
@@ -4,5 +4,6 @@
   search_result__title: label,
   search_result__url: url,
   search_result__highlighted: content.search_api_excerpt,
-  search_result__teaser: content.field_teaser_text
+  search_result__teaser: content.field_teaser_text,
+  search_result__content_type: node.bundle|clean_class
 } %}


### PR DESCRIPTION
## JAKALA: Add Content Type filter to search page

The scope of this task is to add a new filter on the search page and style it based on the updated design.

### Description of work
- Render content type filter dropdown in the search form on the search page.
- Adjust form markup to include proper form item labels.

### Functional testing steps:
- [ ] Ensure content is indexed on /admin/config/search/search-api/index/node_index
- [ ] Navigate to /admin/yalesites/views-settings
- [ ] Enable *Show the Content Type filter*
- [ ] Select all Content Types options and save the form
- [ ] Navigate to /search page
- [ ] Confirm that the search form matches [Figma Designs](https://www.figma.com/design/7dxhigoRGh80M0EOZ3wONc/Design?node-id=1390-4126&t=n2OeRfpi2ItdVmBe-0)
- [ ] Perform a search action based on some text
- [ ] Filter the results using the newly added "Content type" filter
- [ ] Confirm that newly added filter works as expected
- [ ] Verify that form markup meets accessibility requirements

Related PRs:
- https://github.com/yalesites-org/yalesites-project/pull/727
- https://github.com/yalesites-org/component-library-twig/pull/398