### PR TITLE
YSP-662: PRESIDENT: allow center or larger view of video block

### DIFF
--- a/templates/block/layout-builder/block--inline-block--video.html.twig
+++ b/templates/block/layout-builder/block--inline-block--video.html.twig
@@ -1,13 +1,13 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
+{% set video__width = "site" %}
+{% set video__alignment = content.field_style_alignment.0['#markup']|default('left') %}
+
 {% block content %}
 
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set video__width = "content" %}
     {% set video__alignment = "center" %}
-  {% else %}
-    {% set video__width = "site" %}
-    {% set video__alignment = "left" %}
   {% endif %}
 
   {% embed "@molecules/video/yds-video.twig" with {


### PR DESCRIPTION
## [YSP-662: PRESIDENT: allow center or larger view of video block](https://yaleits.atlassian.net/browse/YSP-622)

### Description of work
- Wires the video alignment to the video component

### Functional testing steps:
- [ ] See [YaleSites Project PR](https://github.com/yalesites-org/yalesites-project/pull/751)
