### PR TITLE
YSP-670: Spotlights provide H2 in Banner Section

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -33,6 +33,18 @@ would be used instead resulting in top margin of size-spacing-6.  */
   margin-top: 0;
 }
 
+/* We allow spotlights in the banner now, but they appear a little to close to
+ * the top of the page. This allows us to adjust the top margin to give a
+ * little more space to just the first one.
+ */
+.main-content .layout--banner .layout__region > .text-with-image:first-child,
+.main-content
+  .layout--banner
+  .layout__region
+  > .content-spotlight-portrait:first-child {
+  margin-top: var(--size-spacing-8);
+}
+
 /* The last item inside the `.main-content` area should have some space between
 // it and the site footer (size-spacing-12 below) - unless it is designated as
 // `$flush-bottom` above. Then it will have no bottom-margin separating it from

--- a/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
@@ -5,6 +5,7 @@
 
   {% embed "@molecules/content-spotlight-portrait/yds-content-spotlight-portrait.twig" with {
       content_spotlight_portrait__heading: content.field_heading.0,
+      content_spotlight_portrait__heading_level: content.field_heading_level.0['#markup'],
       content_spotlight_portrait__subheading: content.field_subheading.0,
       content_spotlight_portrait__text: content.field_text,
       content_spotlight_portrait__link__content: content.field_link.0['#title'],

--- a/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
@@ -5,6 +5,7 @@
 
   {% embed "@molecules/text-with-image/yds-text-with-image.twig" with {
     text_with_image__heading: content.field_heading.0,
+    text_with_image__heading_level: content.field_heading_level.0['#markup'],
     text_with_image__subheading: content.field_subheading.0,
     text_with_image__text: content.field_text,
     text_with_image__link__content: content.field_link.0['#title'],


### PR DESCRIPTION
## [YSP-670: Spotlights provide H2 in Banner Section](https://yaleits.atlassian.net/browse/YSP-670)

### Description of work
- Passes `field_heading_level` through to components for spotlights

Please test in yalesites project PR.