### PR TITLE
YSP-680: PRESIDENT: Add dial to image banner to allow default and large image display

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -104,6 +104,11 @@ display: flex;
   margin: 0;
 }
 
+/* Remove bottom margin from the image-banner so that it can be flush with other items */
+.layout--banner .image-banner {
+  margin-bottom: 0;
+}
+
 /* Wingsuit layout builder styles */
 
 .block-categories .layout-builder-browser-block-item img {

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -13,7 +13,6 @@ site header and site footer, respectively.
 ****************
 */
 
-
 /* This `layout-banner override, overrides the .main-content > *:first-child
 statement in web/themes/contrib/atomic/_yale-packages/component-library-twig/components/04-page-layouts/page-layouts.scss
 
@@ -59,6 +58,7 @@ need to have margin-bottom set to 0 */
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .callouts:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .cta-banner:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .grand-hero-banner:last-child,
+.main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .image-banner:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .quick-links:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .text-with-image:not([data-component-theme='default']):last-child, 
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .content-spotlight-portrait:not([data-component-theme='default']):last-child {
@@ -87,7 +87,6 @@ display: flex;
   margin-top: 0;
   margin-bottom: 0;
 }
-
 
 /* Fix for breadcrumb spacing on profile nodes */
 .ys-content-type-profile .main-content .breadcrumbs__wrapper {

--- a/templates/block/layout-builder/block--inline-block--image-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--image-banner.html.twig
@@ -1,21 +1,25 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% set image_banner__video = paragraph.field_media.entity.field_media_video_file.entity.uri.value is not empty %}
+{% set image_banner__image_size = content.field_style_variation.0['#markup']|default('large') %}
 
 {% block content %}
+
   {% embed "@molecules/banner/image/yds-image-banner.twig" with {
-    image_banner__video: image_banner__video,
-    image_banner__content_background: image_banner__content_background
+    image_banner__content__background: content.field_style_color.0['#markup'],
+    image_banner__overlay_variation: 'full',
+    image_banner__size: content.field_style_variation.0['#markup'],
+    image_banner__width: 'site',
   } %}
-  {% block image_banner__video %}
-      {% if image_banner__video %}
+    {% block image_banner__video %}
+      {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is not empty %}
         {% set image_banner__video = true %}
         {{ content.field_media }}
       {% endif %}
     {% endblock %}
 
     {% block image_banner__image %}
-      {% if not image_banner__video %}
+      {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is empty %}
         {{ content.field_media }}
       {% endif %}
     {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--image-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--image-banner.html.twig
@@ -1,7 +1,7 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% set image_banner__video = paragraph.field_media.entity.field_media_video_file.entity.uri.value is not empty %}
-{% set image_banner__image_size = content.field_style_variation.0['#markup']|default('large') %}
+{% set image_banner__image_size = content.field_style_variation.0['#markup']|default('tall') %}
 
 {% block content %}
 


### PR DESCRIPTION
## [YSP-680: PRESIDENT: Add dial to image banner to allow default and large image display](https://yaleits.atlassian.net/browse/YSP-680)

### Other work to be reviewed:
- [YaleSites Project](https://github.com/yalesites-org/yalesites-project/pull/770)
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/423)

### Description of work
- Adds image banner size dial to image banner (large or small)
- Mimics the grand hero layout and styling to have consistent feel

### Functional testing steps:
- [ ] See [yalesites-project PR](https://github.com/yalesites-org/yalesites-project/pull/770)