### PR TITLE
YSP-697: Image Banner not respecting focal point

### DIFF
--- a/templates/field/field--block-content--field-media--image-banner.html.twig
+++ b/templates/field/field--block-content--field-media--image-banner.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}


### PR DESCRIPTION
## [YSP-697: Image Banner not respecting focal point](https://yaleits.atlassian.net/browse/YSP-697)

The div that is inserted for the item seems to be modifying how the image banner behaves, skipping the styling of it to match the grand hero.  By creating this, it allows it to bypass this, picking up the styles similar to the grand hero in Drupal.

### Description of work
- Adds a bypass to the item content so that the extra unsettled div does not get rendered

### Functional testing steps:
- [ ] Use the multidev present in [yalesites repo](https://github.com/yalesites-org/yalesites-project/pull/778)
- [ ] Create an image banner
- [ ] Create a grand hero banner
- [ ] Observe the placement of the image, the boundaries of it, and make sure they match in image shown
- [ ] In their configuration, modify to the "short" version
- [ ] Observe the placement of the image, the boundaries of it, and make sure they match in image shown
