### PR TITLE
v1.10.0: Multiple fixes

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -128,6 +128,14 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
   color: var(--gin-bg-layer3);
 }
 
+/* Dark mode was not passing contrast */
+.gin--dark-mode
+  .linkit-ui-autocomplete.ui-menu
+  .linkit-result-line-wrapper.ui-state-active {
+  color: var(--gin-color-primary);
+  background-color: var(--gin-bg-layer3);
+}
+
 /*
 // Offcanvas toolbar styles
 */

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -295,3 +295,7 @@ div[data-drupal-selector="edit-block-form"] {
   margin-top: auto;
 }
 
+/* Layout containers now have a margin due to stable9 */
+.layout-container {
+  margin: 0;
+}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -299,3 +299,8 @@ div[data-drupal-selector="edit-block-form"] {
 .layout-container {
   margin: 0;
 }
+
+/* On layout builder browser search, hide entries that are actually empty */
+.layout-builder-browser-block-item:has(a[style*="display: none"]) {
+  display: none;
+}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -304,3 +304,9 @@ div[data-drupal-selector="edit-block-form"] {
 .layout-builder-browser-block-item:has(a[style*="display: none"]) {
   display: none;
 }
+
+/* For some reason text-within on tables in dark mode go wrong */
+.gin--dark-mode tr:hover, tr:focus-within {
+  color: var(--gin-color-text);
+  background: var(--gin-bg-secondary);
+}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -319,3 +319,8 @@ div[data-drupal-selector="edit-block-form"] {
 th.field-label {
   z-index: 105;
 }
+
+/* A gradient was displaying on certain states.  This removes it. */
+.has-multiple-fields-remove-button .js .paragraphs-collapsed-description:after {
+  display: none;
+}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -306,7 +306,8 @@ div[data-drupal-selector="edit-block-form"] {
 }
 
 /* For some reason text-within on tables in dark mode go wrong */
-.gin--dark-mode tr:hover, tr:focus-within {
+.gin--dark-mode tr:hover,
+.gin--dark-mode tr:focus-within {
   color: var(--gin-color-text);
   background: var(--gin-bg-secondary);
 }

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -311,3 +311,11 @@ div[data-drupal-selector="edit-block-form"] {
   color: var(--gin-color-text);
   background: var(--gin-bg-secondary);
 }
+
+/**
+ * The header for some reason was allowing the z-index of the table cells to
+ * show above it.
+ */
+th.field-label {
+  z-index: 105;
+}


### PR DESCRIPTION
## v1.10.0 fixes

Work reflected in the [Yalesites project PR](https://github.com/yalesites-org/yalesites-project/pull/793)

### Description of work
- Remove left and right margins on content when in layout builder
- Hide empty blocks shown when filtering blocks in the picker
- Fix accordion colors on text-within
- Fix hover/focus contrast on linkit
- Fix vertical ellipsis menu from allowing items underneath to show
- Remove strange gradient on collapsed paragraphs

### Functional testing steps:
- [ ] Go into layout builder
- [ ] Ensure that the margins are not bumped out and that it resembles the margin after saving
- [ ] Click "Add block"
- [ ] Ensure that when filtering, you don't see empty blocks displaying--you should only see the ones that match your filter.
- [ ] Add an accordion
- [ ] Use tabs to get into the paragraphs portion and make changes.
- [ ] With focus within that paragraph area, move the mouse around that area in and out of the paragraphs to make sure no white background appears
- [ ] Add multiple accordions, collapsing different ones, and ensure no gradient appears next to the edit buttons
- [ ] With some open, click the ellipses next to "Collapse all" and ensure the "edit" button on the first element does not bleed on top of the menu that displays.