### PR TITLE
IYY-283: Site editors can create a ½ - ½ layout and ⅓ - ⅓ - ⅓ layout

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -45,14 +45,32 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
   .layout-builder-block.contextual-region .contextual {
     left: 15vw;
   }
+
+  [data-component-layout="fifty-fifty"] .layout-builder-block.contextual-region .contextual {
+    left: 1vw;
+  }
+
+  [data-component-layout="thirty-thirty-thirty"] .layout-builder-block.contextual-region .contextual {
+    left: 1vw;
+  }
 }
 
+/* 2500 */
 @media only screen and (min-width: 2500px) {
   .layout-builder-block.contextual-region .contextual {
     left: 20vw;
   }
+
+  [data-component-layout="fifty-fifty"] .layout-builder-block.contextual-region .contextual {
+    left: 1vw;
+  }
+
+  [data-component-layout="thirty-thirty-thirty"] .layout-builder-block.contextual-region .contextual {
+    left: 1vw;
+  }
 }
 
+/* Contextual links within contextual-region */
 .layout-builder-block.contextual-region .contextual .contextual-links {
   left: 0;
   right: 0;

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -352,6 +352,9 @@ th.field-label {
 /* Adjust top-margin if an element with an [data-spotlights-position="first" or data-spotlights-position="first-and-last" 
 // is the first element in main content */
 .main-content [data-spotlights-position="first"]:first-child,
-.main-content [data-spotlights-position="first-and-last"]:first-child {
+.main-content [data-spotlights-position="first-and-last"]:first-child,
+/* page-meta will almost always be the first element in main content, so we need a condition for it */
+.main-content > .page-meta + [data-spotlights-position="first-and-last"],
+.main-content > .page-meta + [data-spotlights-position="first"] {
   margin-top: 0;
 } 

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -206,6 +206,22 @@ div[data-drupal-selector="edit-block-form"] {
   background-color: var(--gin-bg-layer2);
 }
 
+
+/* Layout component layout-builder link overrides. */
+.yds-layout.layout-builder__layout[data-component-theme="one"] .layout-builder__link.layout-builder__link--add,
+.yds-layout.layout-builder__layout[data-component-theme="three"] .layout-builder__link.layout-builder__link--add,
+.yds-layout.layout-builder__layout[data-component-theme="four"] .layout-builder__link.layout-builder__link--add {
+  background-color: white !important;
+  border-color: transparent !important;
+}
+
+.yds-layout.layout-builder__layout[data-component-theme="one"] .layout-builder__link.layout-builder__link--add:hover,
+.yds-layout.layout-builder__layout[data-component-theme="three"] .layout-builder__link.layout-builder__link--add:hover,
+.yds-layout.layout-builder__layout[data-component-theme="four"] .layout-builder__link.layout-builder__link--add:hover {
+  background-color: var(--gin-color-primary-hover) !important;
+  border-color: white !important;
+} 
+
 /* Change layoutbuilder configure/UI element colors in dark mode because the defaults don't look good */
 .gin--dark-mode .layout-builder__link--configure:hover {
   background-color: var(--gin-bg-layer) !important;
@@ -324,3 +340,5 @@ th.field-label {
 .has-multiple-fields-remove-button .js .paragraphs-collapsed-description:after {
   display: none;
 }
+
+

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -343,8 +343,15 @@ th.field-label {
 
 
 /* Adjust bottom-margin if an element with [data-spotlights-position="first-and-last"] is the last element on the page */
-/* Or if it is the last element in the main-content area */
+/* Or if [data-spotlights-position="last"] is the last element in main content */
 .main-content [data-spotlights-position="first-and-last"]:last-child,
 .main-content [data-spotlights-position="last"]:last-child {
   margin-bottom: 0;
 }
+
+/* Adjust top-margin if an element with an [data-spotlights-position="first" or data-spotlights-position="first-and-last" 
+// is the first element in main content */
+.main-content [data-spotlights-position="first"]:first-child,
+.main-content [data-spotlights-position="first-and-last"]:first-child {
+  margin-top: 0;
+} 

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -342,3 +342,9 @@ th.field-label {
 }
 
 
+/* Adjust bottom-margin if an element with [data-spotlights-position="first-and-last"] is the last element on the page */
+/* Or if it is the last element in the main-content area */
+.main-content [data-spotlights-position="first-and-last"]:last-child,
+.main-content [data-spotlights-position="last"]:last-child {
+  margin-bottom: 0;
+}

--- a/templates/block/layout-builder/block--inline-block--facts.html.twig
+++ b/templates/block/layout-builder/block--inline-block--facts.html.twig
@@ -2,6 +2,7 @@
 
 {% block content %}
 
+  {{ attach_library('atomic/spotlights') }}
   {% set facts_and_figures__group__bg_image = content.field_media.0 ? 'true' : 'false' %}
 
   {% embed "@organisms/facts-and-figures-group/yds-facts-and-figures-group.twig" with {

--- a/templates/block/layout-builder/block--inline-block--link-grid.html.twig
+++ b/templates/block/layout-builder/block--inline-block--link-grid.html.twig
@@ -9,7 +9,7 @@
   {% endif %}
 
   {% if layout_section == 'ys_layout_two_column_50_50' %}
-    {% set link_grid_theme = 'default' %}
+    {% set link_grid_theme = 'inherit' %}
   {% else %}
     {% set link_grid_theme = content.field_style_color.0['#markup'] %}
   {% endif %}

--- a/templates/block/layout-builder/block--inline-block--link-grid.html.twig
+++ b/templates/block/layout-builder/block--inline-block--link-grid.html.twig
@@ -1,10 +1,17 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
+
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set link_grid__width = "content" %}
   {% else %}
     {% set link_grid__width = "site" %}
+  {% endif %}
+
+  {% if layout_section == 'ys_layout_two_column_50_50' %}
+    {% set link_grid_theme = 'default' %}
+  {% else %}
+    {% set link_grid_theme = content.field_style_color.0['#markup'] %}
   {% endif %}
 
   {# add checks for each link list #}
@@ -14,7 +21,7 @@
   {% set link_grid__links_four = content.field_link_lists.3 %}
 
   {% embed "@molecules/link-grid/yds-link-grid.twig" with {
-    link_grid__theme: content.field_style_color.0['#markup'],
+    link_grid__theme: link_grid_theme,
     link_grid__heading: content.field_heading.0,
   }%}
     {% block link_grid__links_one %}

--- a/templates/block/layout-builder/block--inline-block--tiles.html.twig
+++ b/templates/block/layout-builder/block--inline-block--tiles.html.twig
@@ -1,6 +1,8 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
+  {{ attach_library('atomic/spotlights') }}
+
   {% embed "@organisms/tiles/yds-tiles.twig" with {
     tiles__alignment: content.field_style_alignment.0['#markup'],
     tiles__grid_count: content.field_style_width.0['#markup'],

--- a/templates/layouts/layout--onecol.html.twig
+++ b/templates/layouts/layout--onecol.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme override to display a one-column layout.
+ *
+ * Available variables:
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content for this layout.
+ * - attributes: HTML attributes for the layout <div>.
+ */
+#}
+{%
+  set classes = [
+    'layout',
+    'layout--onecol',
+  ]
+%}
+{% if content.content %}
+  <div{{ attributes.addClass(classes) }}>
+    <div {{ region_attributes.content.addClass('layout__region', 'layout__region--content') }}>
+      {{ content.content }}
+    </div>
+  </div>
+{% endif %}


### PR DESCRIPTION
## [IYY-283: Site editors can create a ½ - ½ layout and ⅓ - ⅓ - ⅓ layout](https://app.clickup.com/t/36718269/IYY-283)

### Description of work
- Adds a twig variable to layout builder components of the current layout section to better style based on context
- Requires [Main Repo PR-826](https://github.com/yalesites-org/yalesites-project/pull/826) and [Component Library Twig PR-442](https://github.com/yalesites-org/component-library-twig/pull/442)

### Functional testing steps:
- [ ] See main testing steps in Main [PR-826](https://github.com/yalesites-org/yalesites-project/pull/826)