### PR TITLE
IYY-285: Site editors can add a caption to Image Banner | Wiring

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -324,3 +324,9 @@ th.field-label {
 .has-multiple-fields-remove-button .js .paragraphs-collapsed-description:after {
   display: none;
 }
+
+/* Fix for caption in image banner */
+/* This is an override for a core CSS file for tables which has too broad styles for .caption */
+.js-layout-builder-block .image-banner__image figcaption.caption  {
+  margin-block-end: 0;
+}

--- a/templates/block/layout-builder/block--inline-block--image-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--image-banner.html.twig
@@ -4,7 +4,6 @@
 {% set image_banner__image_size = content.field_style_variation.0['#markup']|default('tall') %}
 
 {% block content %}
-
   {% embed "@molecules/banner/image/yds-image-banner.twig" with {
     image_banner__content__background: content.field_style_color.0['#markup'],
     image_banner__overlay_variation: 'full',
@@ -20,7 +19,13 @@
 
     {% block image_banner__image %}
       {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is empty %}
-        {{ content.field_media }}
+        {% embed "@atoms/images/image/yds-image.twig" with {
+          figure__caption: content.field_text.0,
+        } %}
+          {% block image__image %}
+            {{ content.field_media }}
+          {% endblock %}
+        {% endembed %}
       {% endif %}
     {% endblock %}
   {% endembed %}


### PR DESCRIPTION
## [IYY-285: Site editors can add a caption to Image Banner](https://fourkitchens.clickup.com/t/36718269/IYY-285)

### Description of work
- Wires Image Banner Caption
- Component Library: https://github.com/yalesites-org/component-library-twig/pull/450
- YaleSites Platform: https://github.com/yalesites-org/yalesites-project/pull/833

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/833
- [ ] Verify wiring looks good here, in this Atomic repo
