### PR TITLE
IYY-287: Install and enable Drupal Book module

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -22,6 +22,9 @@ alert:
 primary-nav:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/primary-nav/yds-primary-nav.js: {}
+secondary-nav:
+  js:
+    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/secondary-nav/yds-secondary-nav.js: {}
 reference-card:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/cards/reference-card/yds-reference-card.js: {}

--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -79,3 +79,7 @@ calendar:
     node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/calendar/yds-calendar.js: {}
   dependencies:
     - core/drupal.ajax
+in-this-section:
+  js:
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/menu/menu-in-this-section-toggle/yds-menu-in-this-section-toggle.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/site-in-this-section/yds-site-in-this-section.js: {}

--- a/templates/form/form-element-label--ys-themes-settings-form--book-navigation.html.twig
+++ b/templates/form/form-element-label--ys-themes-settings-form--book-navigation.html.twig
@@ -1,0 +1,19 @@
+{%
+  set classes = [
+    title_display == 'after' ? 'option',
+    title_display == 'invisible' ? 'visually-hidden',
+    required ? 'js-form--required',
+    required ? 'form--required form-item__label--required',
+    'form-item__label',
+  ]
+%}
+
+{% if title is not empty or required -%}
+
+  <label{{ attributes.addClass(classes) }}>
+    {{ title }}
+    <span class="colors">
+      <span class="color component-color" style="background: var(--global-themes-{{ element['#context']['current_global_theme'] }}-colors-slot-{{ element['#context']['color_theme'] }});"></span>
+    </span>
+  </label>
+{%- endif %}

--- a/templates/navigation/book-tree.html.twig
+++ b/templates/navigation/book-tree.html.twig
@@ -4,5 +4,5 @@
 
 {# Menu #}
 {% include "@organisms/site-in-this-section/yds-site-in-this-section.twig" with {
-  site_section_wrap__theme: 'three'
+  site_section_wrap__theme: getThemeSetting('book_navigation')
 } %}

--- a/templates/navigation/book-tree.html.twig
+++ b/templates/navigation/book-tree.html.twig
@@ -1,4 +1,5 @@
 {{ attach_library('atomic/secondary-nav') }}
+{{ attach_library('atomic/in-this-section') }}
 
 {% set secondary_nav__base_class = 'secondary-nav' %}
 

--- a/templates/navigation/book-tree.html.twig
+++ b/templates/navigation/book-tree.html.twig
@@ -1,0 +1,8 @@
+{{ attach_library('atomic/secondary-nav') }}
+
+{% set secondary_nav__base_class = 'secondary-nav' %}
+
+{# Menu #}
+{% include "@organisms/site-in-this-section/yds-site-in-this-section.twig" with {
+  site_section_wrap__theme: 'three'
+} %}

--- a/templates/node/node--full.html.twig
+++ b/templates/node/node--full.html.twig
@@ -2,4 +2,4 @@
   {{ content.field_banner }}
 {% endif %}
 
-{{ content|without('field_banner') }}
+{{ content|without('field_banner', 'book_navigation') }}


### PR DESCRIPTION
## [IYY-287: Install and enable Drupal Book module](https://app.clickup.com/t/36718269/IYY-287)

### Description of work
- Adds dynamic theming for the book navigation

### Functional testing steps:
- [ ] Login to the site
- [ ] Visit or create a book page (ex: https://pr-834-yalesites-platform.pantheonsite.io/sub-topic-one)
- [ ] At the top of the page, click"Theme Settings"
- [ ] In the side panel, scroll to "Book Navigation theme" and select different options

![Screenshot 2025-01-03 at 1 28 13 PM](https://github.com/user-attachments/assets/448737fe-5f98-45f4-8963-4eefb3440792)

- [ ] Verify that the book navigation theme changes (border colors) dynamically
- [ ] Also change the global theme
- [ ] Save a new setting
- [ ] Verify the new setting takes effect

![Screenshot 2025-01-03 at 1 28 26 PM](https://github.com/user-attachments/assets/9a7f4da1-6c9e-4a34-85f8-564f70c1c35a)
