### PR TITLE
IYY-302: Add vertical text alignment to Spotlights

### DIFF
--- a/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
@@ -15,6 +15,7 @@
       content_spotlight_portrait__style: content.field_style_variation.0['#markup'],
       content_spotlight_portrait__position: content.field_style_position.0['#markup'],
       content_spotlight_portrait__theme: content.field_style_color.0['#markup'],
+      content_spotlight_portrait__vertical_align: content.field_style_alignment.0['#markup'],
   }%}
 
     {% block content_spotlight_portrait__image %}

--- a/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
@@ -16,6 +16,7 @@
     text_with_image__position: content.field_style_position.0['#markup'],
     text_with_image__width: content.field_style_width.0['#markup'],
     text_with_image__theme: content.field_style_color.0['#markup'],
+    text_with_image__vertical_align: content.field_style_alignment.0['#markup'],
   } %}
 
     {% block text_with_image__image %}


### PR DESCRIPTION
## [IYY-302: Add vertical text alignment to Spotlights ](https://fourkitchens.clickup.com/t/36718269/IYY-302)

### Description of work
- Wires vertical alignment options to Content Spotlight Portrait
- Wires vertical alignment options to Content Spotlight Landscape
- CL: https://github.com/yalesites-org/component-library-twig/pull/452

### Functional testing steps:
- [ ] Test here: https://github.com/yalesites-org/yalesites-project/pull/838
