### PR TITLE
IYY-327: Support Video Embed on Image Banner

### DIFF
--- a/templates/block/layout-builder/block--inline-block--video-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--video-banner.html.twig
@@ -1,0 +1,14 @@
+{% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
+
+{% set video_banner__width = content.field_style_width.0['#markup']|default('max') %}
+
+{% block content %}
+
+  {% embed "@molecules/banner/video/yds-video-banner.twig" with {
+    video_banner__width: video_banner__width,
+  } %}
+    {% block video_banner__video %}
+      {{ content.field_media }}
+    {% endblock %}
+  {% endembed %}
+{% endblock %}


### PR DESCRIPTION
## [IYY-327: Support Video Embed on Image Banner](https://fourkitchens.clickup.com/t/36718269/IYY-327)

### Description of work
- Wires new Video Banner to its block type
- YaleSites Platform: https://github.com/yalesites-org/yalesites-project/pull/863
- Component Library: https://github.com/yalesites-org/component-library-twig/pull/466

### Functional testing steps:
- [ ] Test in the main repository: https://github.com/yalesites-org/component-library-twig/pull/466