### PR TITLE
YSP-815: Add asterisks to all required labels

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -323,3 +323,13 @@ html.gin--dark-mode .layout-builder-components-table tr:nth-child(even) {
 html.gin--dark-mode .button.dialog-cancel {
   color: var(--gin-color-button-text);
 }
+
+/*
+ * Mimic glb-form-required in gin
+ */
+label.form-required::after, label.js-form-required::after {
+  content: "*" !important;
+  vertical-align: text-top !important;
+  color: var(--gin-color-danger) !important;
+  background: none !important;
+}


### PR DESCRIPTION
## [YSP-815: Add asterisks to all required labels](https://yaleits.atlassian.net/browse/YSP-815)

It seems that there are cases where they do not append the ginlb tag for some required fields, resulting in it not having a visual indicator of the asterisk.  This mimics that behavior, duplicating the css for the gin_lb version for those without.

### Description of work
- Adds CSS to mimic GinLB's CSS that is currently being used to visually display required markers in other form elements

### Functional testing steps:
- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] ...
