### PR TITLE
IYY-335: Follow-ups on Book Module/Secondary Nav

### DIFF
--- a/templates/block/block--custom-book-navigation.html.twig
+++ b/templates/block/block--custom-book-navigation.html.twig
@@ -1,0 +1,40 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - in_preview: Whether the plugin is being rendered in preview mode.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+
+<div{{ attributes }}>
+  <div class="prevent-operation"></div>
+    {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>{{ label }}</h2>
+    {% endif %}
+    {{ title_suffix }}
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+</div>


### PR DESCRIPTION
## [IYY-335: Follow-ups on Book Module/Secondary Nav](https://app.clickup.com/t/36718269/IYY-335)

### Description of work
- Prevents the ability to click on the collection links in the collection navigation while in layout builder.

### Functional testing steps:
- [ ] Test over in [main PR-894](https://github.com/yalesites-org/yalesites-project/pull/894) 
