### PR TITLE
YSP-574: Paragraph blocks - items 3 dot menu option not showing properly

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -312,6 +312,12 @@ div[data-drupal-selector="edit-block-form"] {
   background: var(--gin-bg-secondary);
 }
 
+/* To fix ckeditor's modification of paragraph action buttons */
+#drupal-off-canvas-wrapper .ui-dialog-content div:not([data-drupal-ck-style-fence] *) {
+  width: inherit !important;
+  max-width: inherit !important;
+}
+
 /**
  * The header for some reason was allowing the z-index of the table cells to
  * show above it.


### PR DESCRIPTION
## [YSP-574: Paragraph blocks - items 3 dot menu option not showing properly](https://yaleits.atlassian.net/browse/YSP-574)

### Description of work
- Overload CKEditor's width settings on paragraph-based actions

### Functional testing steps:
- [ ] Visit the [test multidev](https://github.com/yalesites-org/yalesites-project/pull/906)
- [ ] Add a custom card
- [ ] Ensure that the three dots next to each paragraph is visible
- [ ] Resize the browser window to various widths and ensure the 3 dotted actions are visible
- [ ] Save the custom card
- [ ] Edit the custom card
- [ ] Ensure that the three dots next to each paragraph is visible
- [ ] Resize the browser window to various widths and ensure the 3 dotted actions are visible
- [ ] Try other paragraph-based blocks, like accordion
