### PR TITLE
YSP-738 :: Reimplement hiding hamburger menu if no menu items exist

### DIFF
--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -5,6 +5,13 @@
   {% set site_header__site_name_is_image = getHeaderSetting('site_name_image') %}
 {% endif %}
 
+{# set primary and utility nave variables equal to their drupal elements #}
+{# this is necessary to pass the truthiness of the elements to the site-header organism #}
+{# which will set {% set site_header__hamburger = 'yes' %} #}
+{# and render the hamburger icon if the primary nav exists or the ulitity nav exists #}
+{% set primary_nav__items = elements.main_navigation.content['#items'] is iterable %}
+{% set utility_nav__items = elements.utility_navigation.content['#items'] is iterable %}
+
 {# Dropdown button links in utility navigation #}
 {% set utility_nav_button_title = getHeaderSetting('dropdown_button_title') %}
 {% set utility_nav__dropdown__items = drupal_menu('utility-drop-button-navigation')['#items'] %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -30,6 +30,8 @@
   site_header__nav_position: getHeaderSetting('nav_position'),
   site_header__branding_name: getHeaderSetting('site_wide_branding_name')|default('Yale University'),
   site_header__branding_link: getHeaderSetting('site_wide_branding_link')|default('https://www.yale.edu'),
+  primary_nav__items: primary_nav__items,
+  utility_nav__items: utility_nav__items,
   drupal_utility_nav: elements.utility_navigation,
 } %}
   {% block site_header__primary_nav %}


### PR DESCRIPTION
## [YSP-738: Reimplement hiding hamburger menu if no menu items exist](https://yaleits.atlassian.net/browse/YSP-738)

### Description of work
- Hides the hamburger menu if there are no items in the main and utility menus.

### Functional testing steps:
- [ ] Go to administer menus for [main](https://pr-919-yalesites-platform.pantheonsite.io/admin/structure/menu/manage/main) and [utility](https://pr-919-yalesites-platform.pantheonsite.io/admin/structure/menu/manage/utility-navigation) menus
- [  ] Delete or disable all menu items in both menus, verify you cannot see the hamburger menu
- [  ] Enable at least one menu item in either menu, verify you can see the hamburger menu.
