### PR TITLE
IYY-345: Breadcrumbs at level 2 instead of level 3

### DIFF
--- a/templates/navigation/ys-breadcrumb-block.html.twig
+++ b/templates/navigation/ys-breadcrumb-block.html.twig
@@ -1,3 +1,5 @@
 {{ attach_library('atomic/breadcrumbs' ) }}
 
-{% include '@organisms/menu/breadcrumbs/yds-breadcrumbs.twig' %}
+{% include '@organisms/menu/breadcrumbs/yds-breadcrumbs.twig' with {
+	breadcrumbs__deep: 2,
+} %}


### PR DESCRIPTION
## [IYY-345: Breadcrumbs at level 2 instead of level 3](https://fourkitchens.clickup.com/t/36718269/IYY-345)

### Description of work
- Add breadcrumb depth functionality

### Work also done at:
- [Component Library Twig](https://github.com/yalesites-org/yalesites-project/pull/898)