### PR TITLE
 YSP-761 :: Add available blocks to regions for new layouts #490 

### DIFF
--- a/templates/node/node--post--list-item.html.twig
+++ b/templates/node/node--post--list-item.html.twig
@@ -9,39 +9,35 @@
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
-{% embed "@organisms/component-wrapper/yds-component-wrapper.twig" %}
-  {% block component_wrapper_inner %}
-    {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
-      reference_card__overline: date__formatted,
-      reference_card__heading: heading,
-      reference_card__url: url,
-      reference_card__snippet: content.field_teaser_text,
-      reference_card__image_aria: heading[0]['#context'].value,
-      reference_card__overlay: node.pin_label,
-      show_categories: node.show_categories,
-      show_tags: node.show_tags,
-      show_thumbnail: node.show_thumbnail,
-      reference_card__eyebrow: content.field_teaser_lead_in[0]['#context'].value,
-      show_eyebrow: node.show_eyebrow,
-    } %}
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__overline: date__formatted,
+  reference_card__heading: heading,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image_aria: heading[0]['#context'].value,
+  reference_card__overlay: node.pin_label,
+  show_categories: node.show_categories,
+  show_tags: node.show_tags,
+  show_thumbnail: node.show_thumbnail,
+  reference_card__eyebrow: content.field_teaser_lead_in[0]['#context'].value,
+  show_eyebrow: node.show_eyebrow,
+} %}
 
-      {% block reference_card__tags %}
-        {{ content.field_tags }}
-      {% endblock %}
+  {% block reference_card__tags %}
+    {{ content.field_tags }}
+  {% endblock %}
 
-      {% block reference_card__categories %}
-        {{ content.field_category }}
-      {% endblock %}
+  {% block reference_card__categories %}
+    {{ content.field_category }}
+  {% endblock %}
 
-      {% block reference_card__image %}
+  {% block reference_card__image %}
 
-        {% if content.field_teaser_media[0] %}
-          {{ content.field_teaser_media }}
-        {% elseif getCoreSetting('image_fallback.teaser') %}
-          {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
-        {% endif %}
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_list_3_2') }}
+    {% endif %}
 
-      {% endblock %}
-    {% endembed %}
   {% endblock %}
 {% endembed %}


### PR DESCRIPTION
## [YSP-761: Add available blocks to regions for new layouts](https://yaleits.atlassian.net/browse/YSP-761)

### Description of work

- Tabs: Transparent tab buttons on dark backgrounds and improved text contrast.
- Pre-built Forms: Adjusted input background colors and fixed asterisk color for visibility.
- Quote: Dynamically adjusted text color based on section background.
- Divider: Updated color to adapt to section background.
- Button: Colors adjusted for proper contrast with section backgrounds.
- Accordion: Applied color adjustments similar to tabs.
- Reference Card: Repositioned text area for better text width and layout.

### Work also done at:
- [YaleSites Project](https://github.com/yalesites-org/yalesites-project/pull/898)
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/490)
