### PR TITLE
YSP-814:: Remove `Show Thumbnails` in reference card to use `with-image`

### DIFF
--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -46,7 +46,7 @@
   reference_card__subheading: date__formatted,
   reference_card__url: url,
   reference_card__snippet: content.field_teaser_text,
-  reference_card__image: 'true',
+  reference_card__image: node.show_thumbnail ? 'true' : 'false',
   reference_card__cta_primary__href: ticket_url,
   reference_card__cta_primary__content: cost_button_text,
   reference_card__cta_secondary__content: (node.hide_add_to_calendar) ? null : 'Add to Calendar',
@@ -55,7 +55,6 @@
   reference_card__overlay: node.pin_label,
   show_categories: node.show_categories,
   show_tags: node.show_tags,
-  show_thumbnail: node.show_thumbnail,
 } %}
 
   {% block reference_card__tags %}

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -42,7 +42,7 @@
   reference_card__subheading: date__formatted,
   reference_card__url: url,
   reference_card__snippet: content.field_teaser_text,
-  reference_card__image: 'true',
+  reference_card__image: node.show_thumbnail ? 'true' : 'false',
   reference_card__cta_primary__href: ticket_url,
   reference_card__cta_primary__content: cost_button_text,
   reference_card__cta_secondary__content: (node.hide_add_to_calendar) ? null : 'Add to Calendar',
@@ -51,7 +51,6 @@
   reference_card__overlay: node.pin_label,
   show_categories: node.show_categories,
   show_tags: node.show_tags,
-  show_thumbnail: node.show_thumbnail,
 } %}
 
   {% block reference_card__tags %}

--- a/templates/node/node--page--card.html.twig
+++ b/templates/node/node--page--card.html.twig
@@ -7,12 +7,11 @@
   reference_card__subheading: date__formatted,
   reference_card__url: url,
   reference_card__snippet: content.field_teaser_text,
-  reference_card__image: 'true',
+  reference_card__image: node.show_thumbnail ? 'true' : 'false',
   reference_card__image_aria: heading[0]['#context'].value,
   reference_card__overlay: node.pin_label,
   show_categories: node.show_categories,
   show_tags: node.show_tags,
-  show_thumbnail: node.show_thumbnail,
 } %}
 
   {% block reference_card__tags %}

--- a/templates/node/node--page--list-item.html.twig
+++ b/templates/node/node--page--list-item.html.twig
@@ -6,11 +6,11 @@
   reference_card__heading: heading,
   reference_card__url: url,
   reference_card__snippet: content.field_teaser_text,
+  reference_card__image: node.show_thumbnail ? 'true' : 'false',
   reference_card__image_aria: heading[0]['#context'].value,
   reference_card__overlay: node.pin_label,
   show_categories: node.show_categories,
   show_tags: node.show_tags,
-  show_thumbnail: node.show_thumbnail,
 } %}
 
   {% block reference_card__tags %}

--- a/templates/node/node--post--card.html.twig
+++ b/templates/node/node--post--card.html.twig
@@ -13,11 +13,11 @@
   reference_card__heading: heading,
   reference_card__url: url,
   reference_card__snippet: content.field_teaser_text,
+  reference_card__image: node.show_thumbnail ? 'true' : 'false',
   reference_card__image_aria: heading[0]['#context'].value,
   reference_card__overlay: node.pin_label,
   show_categories: node.show_categories,
   show_tags: node.show_tags,
-  show_thumbnail: node.show_thumbnail,
   reference_card__eyebrow: content.field_teaser_lead_in[0]['#context'].value,
   show_eyebrow: node.show_eyebrow,
 } %}

--- a/templates/node/node--post--list-item.html.twig
+++ b/templates/node/node--post--list-item.html.twig
@@ -10,17 +10,17 @@
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
 {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
-  reference_card__overline: date__formatted,
-  reference_card__heading: heading,
-  reference_card__url: url,
-  reference_card__snippet: content.field_teaser_text,
-  reference_card__image_aria: heading[0]['#context'].value,
-  reference_card__overlay: node.pin_label,
-  show_categories: node.show_categories,
-  show_tags: node.show_tags,
-  show_thumbnail: node.show_thumbnail,
-  reference_card__eyebrow: content.field_teaser_lead_in[0]['#context'].value,
-  show_eyebrow: node.show_eyebrow,
+    reference_card__overline: date__formatted,
+    reference_card__heading: heading,
+    reference_card__url: url,
+    reference_card__snippet: content.field_teaser_text,
+    reference_card__image: node.show_thumbnail ? 'true' : 'false',
+    reference_card__image_aria: heading[0]['#context'].value,
+    reference_card__overlay: node.pin_label,
+    show_categories: node.show_categories,
+    show_tags: node.show_tags,
+    reference_card__eyebrow: content.field_teaser_lead_in[0]['#context'].value,
+    show_eyebrow: node.show_eyebrow,
 } %}
 
   {% block reference_card__tags %}

--- a/templates/node/node--profile--card.html.twig
+++ b/templates/node/node--profile--card.html.twig
@@ -7,12 +7,11 @@
   reference_card__subheading: content.field_position,
   reference_card__url: url,
   reference_card__snippet: content.field_subtitle,
-  reference_card__image: 'true',
+  reference_card__image: node.show_thumbnail ? 'true' : 'false',
   reference_card__image_aria: heading[0]['#context'].value,
   reference_card__overlay: node.pin_label,
   show_categories: node.show_categories,
   show_tags: node.show_tags,
-  show_thumbnail: node.show_thumbnail,
 } %}
 
   {% block reference_card__tags %}

--- a/templates/node/node--profile--list-item.html.twig
+++ b/templates/node/node--profile--list-item.html.twig
@@ -7,11 +7,11 @@
   reference_card__subheading: content.field_position,
   reference_card__url: url,
   reference_card__snippet: content.field_subtitle,
+  reference_card__image: node.show_thumbnail ? 'true' : 'false',
   reference_card__image_aria: heading[0]['#context'].value,
   reference_card__overlay: node.pin_label,
   show_categories: node.show_categories,
   show_tags: node.show_tags,
-  show_thumbnail: node.show_thumbnail,
 } %}
 
   {% block reference_card__tags %}


### PR DESCRIPTION
## [YSP-814: Remove `Show Thumbnails` in reference card to use `with-image`](https://yaleits.atlassian.net/browse/YSP-814)

### Description of work
- Changes the reference_card__image property (which corresponds to 'withImage' in js files) to be set using the show_thumbnails property from ys_views_basic so that the show_thumbnail is no longer required in the component. 

Note: In the twig file, there were two properties being set to control the image display: reference_card__image and show_thumbnail. I have updated it so that it only uses reference_card__image which is set by 'Show Teaser Image' or 'withImage' if in Storybook, and is by default set to 'true' (the canonical node, Featured Card block).

### Testing Link(s)
- [ ] Multidev for testing here: https://pr-925-yalesites-platform.pantheonsite.io/

### Functional Review Steps
- [ ] In Storybook, verify the 'withImage' control works to show/hide the image in card components and card collections
- [ ] Log into the multidev, create a node featured card of any type, verify the image appears. I have been testing here: https://pr-925-yalesites-platform.pantheonsite.io/example-landing-page
- [ ] Create a view component of any type. Verify that "Show Teaser Image" toggles the image display

Uses component library branch: https://github.com/yalesites-org/component-library-twig/pull/493
