### PR TITLE
YSP-589: Add Page Content Type Support to Reference Card Block

### DIFF
--- a/templates/node/node--page--single.html.twig
+++ b/templates/node/node--page--single.html.twig
@@ -1,0 +1,24 @@
+{{ attach_library('atomic/reference-card') }}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__heading: heading,
+  reference_card__url: url,
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__eyebrow: content.field_teaser_lead_in[0]['#context'].value,
+  show_eyebrow: node.show_eyebrow,
+  reference_card__overlay: node.pin_label,
+} %}
+  {% block reference_card__image %}
+
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+    {% elseif getCoreSetting('image_fallback.teaser') %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_secondary_3_2') }}
+    {% endif %}
+
+  {% endblock %}
+{% endembed %}
+


### PR DESCRIPTION
## [YSP-589: Add Page Content Type Support to Reference Card Block](https://yaleits.atlassian.net/browse/YSP-589)

### Other repositories needing review
- [Yalesites Project](https://github.com/yalesites-org/yalesites-project/pull/934)

### Description of work
- Introduce a new Twig template for single page nodes. This template embeds the reference card component and dynamically sets its properties such as heading, URL, snippet, and eyebrow. It also handles fallback logic for teaser media images.

### Functional testing steps:
- See [YaleSites Project PR for steps](https://github.com/yalesites-org/yalesites-project/pull/934)