### PR TITLE
YSP-822: Add Event Time to Event Display Modes

### DIFF
--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -20,6 +20,8 @@
 {% set date__formatted %}
   {% include "@atoms/date-time/yds-date-time.twig" with {
     date_time__start: content.field_event_date[delta].start_time['#markup'],
+    date_time__end: content.field_event_date[delta].end_time['#markup'],
+    date_time__format: 'same_day_diff_time',
   } %} {{multi_day_text}}
 {% endset %}
 

--- a/templates/node/node--event--condensed.html.twig
+++ b/templates/node/node--event--condensed.html.twig
@@ -26,6 +26,8 @@
 {% set date__formatted %}
   {% include "@atoms/date-time/yds-date-time.twig" with {
     date_time__start: content.field_event_date[delta].start_time['#markup'],
+    date_time__end: content.field_event_date[delta].end_time['#markup'],
+    date_time__format: 'same_day_diff_time',
   } %} {{multi_day_text}}
 {% endset %}
 

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -19,7 +19,9 @@
 {% set date__formatted %}
   {% include "@atoms/date-time/yds-date-time.twig" with {
     date_time__start: content.field_event_date[delta].start_time['#markup'],
-  } %} {{ multi_day_text }}
+    date_time__end: content.field_event_date[delta].end_time['#markup'],
+    date_time__format: 'same_day_diff_time',
+  } %} {{multi_day_text}}
 {% endset %}
 
 {% if content.field_localist_event_experience.0 %}


### PR DESCRIPTION
## [YSP-822: Add Event Time to Event Display Modes](https://yaleits.atlassian.net/browse/YSP-822)

### Other work needing reviewed
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/497)

### Description of work
- Adds time to each event view display type (minus calendar)
- Date time changes were needed in [component library](https://github.com/yalesites-org/component-library-twig/pull/497) to accommodate this

### Functional testing steps:
- [ ] Create an event view
- [ ] Pick any display type except calendar
- [ ] Verify that the time appears
- [ ] Try different permutations of events
  - [ ] A single event with a single date and time
  - [ ] A single event with an all day set
  - [ ] Multdate events with Multidate times
  - [ ] A single event with multiple dates
