### PR TITLE
YSP-880: Change default site email from noreply@yale.edu to noreply@noreply.yale.edu

### DIFF
--- a/templates/block/layout-builder/block--inline-block--webform.html.twig
+++ b/templates/block/layout-builder/block--inline-block--webform.html.twig
@@ -8,6 +8,15 @@
   } %}
 
     {% block component_wrapper_inner %}
+      {% if content['#configuration_issue'] %}
+        {% include "@molecules/inline-message/yds-inline-message.twig" with {
+            inline_message__heading: "Configuration issue",
+            inline_message__content: content['#configuration_issue'],
+            inline_message__type: 'info',
+            inline_message__theme: 'two',
+          } %}
+      {% endif %}
+
       {{content.field_form}}
     {% endblock %}
 


### PR DESCRIPTION
## [YSP-880: Change default site email from noreply@yale.edu to noreply@noreply.yale.edu](https://yaleits.atlassian.net/browse/YSP-880)

### Other PRs needing review
- [Yalesites Project](https://github.com/yalesites-org/yalesites-project/pull/936)

### Description of work
- Include an inline message for configuration issues in the webform block template. This message displays when the `#configuration_issue` key is present in the content array. The message uses the `yds-inline-message` component with a heading, content, type, and theme for better user feedback.