### PR TITLE
YSP-875: Text: Tables in a section have a color contrast issue

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -326,13 +326,6 @@ div[data-drupal-selector="edit-block-form"] {
   display: none;
 }
 
-/* For some reason text-within on tables in dark mode go wrong */
-.gin--dark-mode tr:hover,
-.gin--dark-mode tr:focus-within {
-  color: var(--gin-color-text);
-  background: var(--gin-bg-secondary);
-}
-
 /* To fix ckeditor's modification of paragraph action buttons */
 #drupal-off-canvas-wrapper .ui-dialog-content div:not([data-drupal-ck-style-fence] *) {
   width: inherit !important;


### PR DESCRIPTION
## [YSP-875: Text: Tables in a section have a color contrast issue](https://yaleits.atlassian.net/browse/YSP-875)

### Other related PRs
- [Multidev PR](https://github.com/yalesites-org/yalesites-project/pull/952)
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/506)

### Description of work
- Removed unnecessary dark mode table hover and focus-within styles that caused incorrect text rendering.

### Functional testing steps:
- [ ] Create a table in Drupal
- [ ] Hover over it
- [ ] Verify no hover state occurs
