### PR TITLE
YSP-892: Content Collection Move

### DIFF
--- a/components/_settings/_config.css
+++ b/components/_settings/_config.css
@@ -28,3 +28,12 @@
 .toolbar-horizontal .local-tasks-toolbar-tab .toolbar-menu {
   float: none;
 }
+
+/*
+ * It was requested to add more space if the secondary nav was with
+ * a title.  This is a workaround to add more space if the title is
+ * visible.
+ */
+#block-atomic-custombooknavigation + div:has(.page-title.visible) {
+  margin-top: var(--size-spacing-4);
+}


### PR DESCRIPTION
## [YSP-892: Content Collection Move](https://yaleits.atlassian.net/browse/YSP-892)

### Description of work
- Added a workaround to provide additional spacing when the secondary navigation contains a visible page title. This ensures better visual alignment and spacing consistency.

Affected component:
- #block-atomic-custombooknavigation with visible .page-title

### Functional testing steps:
- [ ] Create a content collection
- [ ] Create a new page with a title
- [ ] Ensure that there is space in between both the menu and the title that looks acceptable
- [ ] Create a new page without a title that is part of the collection
- [ ] Ensure that the spacing does not reflect what you saw with the title
