### PR TITLE
IYY-389 :: Content collection bottom padding

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -65,7 +65,7 @@ need to have margin-bottom set to 0 */
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .grand-hero-banner:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .image-banner:last-child,
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .quick-links:last-child,
-.main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .text-with-image:not([data-component-theme='default']):last-child,
+.main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .text-with-image:not([data-component-theme='default']):last-child, 
 .main-content .layout.layout--onecol:last-of-type .layout__region--content:last-child .content-spotlight-portrait:not([data-component-theme='default']):last-child {
   margin-bottom: 0;
 }
@@ -206,7 +206,7 @@ div[data-drupal-selector="edit-block-form"] {
 }
 
 
-#drupal-off-canvas-wrapper .draggable:hover,
+#drupal-off-canvas-wrapper .draggable:hover, 
 #drupal-off-canvas-wrapper .draggable:focus-within {
   background-color: var(--gin-bg-layer2);
 }
@@ -225,7 +225,7 @@ div[data-drupal-selector="edit-block-form"] {
 .yds-layout.layout-builder__layout[data-component-theme="four"] .layout-builder__link.layout-builder__link--add:hover {
   background-color: var(--gin-color-primary-hover) !important;
   border-color: white !important;
-}
+} 
 
 /* Change layoutbuilder configure/UI element colors in dark mode because the defaults don't look good */
 .gin--dark-mode .layout-builder__link--configure:hover {
@@ -251,7 +251,7 @@ div[data-drupal-selector="edit-block-form"] {
 }
 
 /* Override layout builder block categories hover state in dark mode */
-.gin--dark-mode .glb-grid-item:hover,
+.gin--dark-mode .glb-grid-item:hover, 
 .gin--dark-mode .layout-builder-browser-block-item:hover {
   color: white;
   background-color: var(--gin-color-primary-light-rgb) !important;
@@ -327,8 +327,8 @@ div[data-drupal-selector="edit-block-form"] {
 }
 
 /* For some reason text-within on tables in dark mode go wrong */
-.gin--dark-mode tr:hover td,
-.gin--dark-mode tr:focus-within td {
+.gin--dark-mode tr:hover,
+.gin--dark-mode tr:focus-within {
   color: var(--gin-color-text);
   background: var(--gin-bg-secondary);
 }
@@ -365,12 +365,19 @@ th.field-label {
   margin-bottom: 0;
 }
 
-/* Adjust top-margin if an element with an [data-spotlights-position="first" or data-spotlights-position="first-and-last"
-// is the first element in main content */
-.main-content [data-spotlights-position="first"]:first-child,
-.main-content [data-spotlights-position="first-and-last"]:first-child,
-/* page-meta will almost always be the first element in main content, so we need a condition for it */
-.main-content > .page-meta + [data-spotlights-position="first-and-last"],
-.main-content > .page-meta + [data-spotlights-position="first"] {
+/*
+  Adjust top-margin if an element with [data-spotlights-position="first"] 
+  or [data-spotlights-position="first-and-last"] is the first element 
+  in main content — only if there is no active content collection.
+*/
+.main-content:not(:has(.in-this-section)) [data-spotlights-position="first"]:first-child,
+.main-content:not(:has(.in-this-section)) [data-spotlights-position="first-and-last"]:first-child,
+/*
+  Page-meta will almost always be the first element in main content,
+  so we need a condition for it — this only applies if there is no
+  active content collection.
+*/
+.main-content > .page-meta:not(:has(.in-this-section)) + [data-spotlights-position="first-and-last"],
+.main-content > .page-meta:not(:has(.in-this-section)) + [data-spotlights-position="first"] {
   margin-top: 0;
-}
+} 

--- a/templates/block/layout-builder/block--inline-block--button-link.html.twig
+++ b/templates/block/layout-builder/block--inline-block--button-link.html.twig
@@ -13,7 +13,7 @@
   {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
     component_wrapper__width: component_wrapper__width,
     component_wrapper__label: content.field_heading,
-    component__modifiers: ['no-top-margin'],
+    component__modifiers: ['no-top-margin', 'cta-group'],
   } %}
     {% block component_wrapper_inner %}
       <div class="cta-group">

--- a/templates/block/layout-builder/block--ys-taxonomy-display-block.html.twig
+++ b/templates/block/layout-builder/block--ys-taxonomy-display-block.html.twig
@@ -1,0 +1,7 @@
+{% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
+
+{% block content %}
+
+  {{ content }}
+
+{% endblock %}


### PR DESCRIPTION
## [IYY-389: Content collection bottom padding](https://fourkitchens.clickup.com/t/36718269/IYY-389)

### Description of work
- Fix content collection bottom padding to reveal bottom border.

### Functional testing steps:

- [ ] Refer to the steps provided in this [PR](https://github.com/yalesites-org/yalesites-project/pull/962).

### Work also done at:
- [Yalesites Project](https://github.com/yalesites-org/component-library-twig/pull/509)
- [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/512)