### PR TITLE
YSP-928: Layout Builder Block Tables in Dark Mode Unreadable

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -374,3 +374,8 @@ th.field-label {
 .main-content > .page-meta + [data-spotlights-position="first"] {
   margin-top: 0;
 }
+
+/* Fixes dark mode weight links to have better contrast. */
+.gin--dark-mode button.tabledrag-toggle-weight {
+  color: var(--gin-color-text);
+}


### PR DESCRIPTION
## [YSP-928: Layout Builder Block Tables in Dark Mode Unreadable](https://yaleits.atlassian.net/browse/YSP-928)

### Work also done in
- [ ] [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/515)

### Description of work
- Added a CSS rule to enhance the contrast of weight links in dark mode by setting their color to `var(--gin-color-text)`. This ensures better readability and accessibility for users in dark mode.

### Functional testing steps:
- [ ] Test on [Multidev](https://github.com/yalesites-org/yalesites-project/pull/973)