### PR TITLE
Hotfix: YSP-943/YSP-945: Grand Hero and Table fixes

### DIFF
--- a/css/ckeditor5.css
+++ b/css/ckeditor5.css
@@ -56,3 +56,11 @@ div[contenteditable="true"] #drupal-off-canvas [data-drupal-ck-style-fence] .ck-
   width: 100%;
   max-width: 100%;
 }
+
+/*
+* CKeditor was overwriting how tables should look and somehow using the
+* incorrect gin text color.  This ensures that it passes contrast.
+*/
+.gin--dark-mode .ck-widget.table table td.ck-editor__nested-editable:focus {
+  color: black;
+}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -384,3 +384,14 @@ th.field-label {
 .gin--dark-mode button.tabledrag-toggle-weight {
   color: var(--gin-color-text);
 }
+
+/*
+ * Claro tables.scss is overwriting our _table.css when in layout builder.
+ * This is a workaround to fix the issue.
+ */
+.gin--dark-mode #layout-builder .yds-layout th {
+  --header-row-bg: var(--color-gray-200);
+
+  background-color: var(--header-row-bg);
+  color: var(--color-gray-700);
+}

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -326,11 +326,16 @@ div[data-drupal-selector="edit-block-form"] {
   display: none;
 }
 
-/* For some reason text-within on tables in dark mode go wrong */
-.gin--dark-mode tr:hover td,
-.gin--dark-mode tr:focus-within td {
-  color: var(--gin-color-text);
+/* Because we are now using global table styling, we need to override the
+ * default table styles for the dialog boxes that layout builder uses. */
+.gin--dark-mode .ui-dialog table tr:nth-child(odd) td {
   background: var(--gin-bg-secondary);
+  color: var(--gin-color-text);
+}
+
+.gin--dark-mode .ui-dialog table tr:nth-child(even) td {
+  background: var(--gin-bg-layer);
+  color: var(--gin-color-text);
 }
 
 /* To fix ckeditor's modification of paragraph action buttons */

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -389,7 +389,7 @@ th.field-label {
  * Claro tables.scss is overwriting our _table.css when in layout builder.
  * This is a workaround to fix the issue.
  */
-.gin--dark-mode #layout-builder .yds-layout th {
+#layout-builder .yds-layout th {
   --header-row-bg: var(--color-gray-200);
 
   background-color: var(--header-row-bg);

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -326,18 +326,6 @@ div[data-drupal-selector="edit-block-form"] {
   display: none;
 }
 
-/* Because we are now using global table styling, we need to override the
- * default table styles for the dialog boxes that layout builder uses. */
-.gin--dark-mode .ui-dialog table tr:nth-child(odd) td {
-  background: var(--gin-bg-secondary);
-  color: var(--gin-color-text);
-}
-
-.gin--dark-mode .ui-dialog table tr:nth-child(even) td {
-  background: var(--gin-bg-layer);
-  color: var(--gin-color-text);
-}
-
 /* To fix ckeditor's modification of paragraph action buttons */
 #drupal-off-canvas-wrapper .ui-dialog-content div:not([data-drupal-ck-style-fence] *) {
   width: inherit !important;
@@ -386,12 +374,17 @@ th.field-label {
 }
 
 /*
- * Claro tables.scss is overwriting our _table.css when in layout builder.
- * This is a workaround to fix the issue.
+ * For layout builder paragraph tables, we need to override the default in dark mode.
+ * This is due to otehr things overloading it in the wrong way, like our _table.css,
+ * gin, and ckeditor.
  */
-#layout-builder .yds-layout th {
-  --header-row-bg: var(--color-gray-200);
+.gin--dark-mode .field-multiple-table.glb-table tr.draggable > td {
+  background-color: var(--gin-bg-layer); 
+  color: var(--gin-color-text); 
+} 
 
-  background-color: var(--header-row-bg);
-  color: var(--color-gray-700);
-}
+.gin--dark-mode .field-multiple-table.glb-table tr.draggable:nth-child(odd) > td { 
+  background-color: var(--gin-bg-layer2); 
+  color: var(--gin-color-text); 
+} 
+


### PR DESCRIPTION
## [Hotfix: YSP-943: Grand Hero fixes](https://yaleits.atlassian.net/browse/YSP-943)
## [Hotfix: YSP-945: Accordion: Tables have a color contrast issue](https://yaleits.atlassian.net/browse/YSP-943)

### Description of work
- Override global table styles for tables inside layout builder dialog boxes in dark mode.
- Work also done in [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/520) and [Yalesites Project](https://github.com/yalesites-org/yalesites-project/pull/980)

### Functional testing steps:
- [ ] Visit the [PR multidev](https://github.com/yalesites-org/yalesites-project/pull/980)
- [ ] Edit a block that has paragraphs
- [ ] Ensure that hover no longer happens on paragraph table rows
- [ ] Ensure that there is a striping between odd and even rows
