### PR TITLE
YSP-738: Hide hamburger menu if no nav items exist

### DIFF
--- a/atomic.info.yml
+++ b/atomic.info.yml
@@ -8,6 +8,7 @@ libraries:
   - atomic/global
   - atomic/layout-builder
   - atomic/fontawesome
+  - atomic/disable-menu
 
 ckeditor5-stylesheets:
   - css/ckeditor5.css

--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -14,6 +14,9 @@ global:
     node_modules/@yalesites-org/component-library-twig/dist/js/link-treatment.js: {}
   dependencies:
     - core/drupal
+disable-menu:
+  js:
+    js/disable-menu.js: {}
 accordion:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/accordion/yds-accordion.js: {}

--- a/js/disable-menu.js
+++ b/js/disable-menu.js
@@ -1,0 +1,11 @@
+Drupal.behaviors.disableMenu = {
+  attach: function (context, settings) {
+    const utilityMenuElement = document.querySelectorAll('.utility-nav__item');
+    const primaryMenuElement = document.querySelectorAll('.primary-nav__item');
+    const hamburgerMenuElement = document.querySelector('.menu-toggle');
+
+    if (utilityMenuElement.length === 0 && primaryMenuElement.length === 0) {
+      hamburgerMenuElement.style.display = 'none';
+    }
+  }
+}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -5,13 +5,6 @@
   {% set site_header__site_name_is_image = getHeaderSetting('site_name_image') %}
 {% endif %}
 
-{# set primary and utility nave variables equal to their drupal elements #}
-{# this is necessary to pass the truthiness of the elements to the site-header organism #}
-{# which will set {% set site_header__hamburger = 'yes' %} #}
-{# and render the hamburger icon if the primary nav exists or the ulitity nav exists #}
-{% set primary_nav__items = elements.main_navigation.content['#items'] is iterable %}
-{% set utility_nav__items = elements.utility_navigation.content['#items'] is iterable %}
-
 {# Dropdown button links in utility navigation #}
 {% set utility_nav_button_title = getHeaderSetting('dropdown_button_title') %}
 {% set utility_nav__dropdown__items = drupal_menu('utility-drop-button-navigation')['#items'] %}
@@ -30,8 +23,6 @@
   site_header__nav_position: getHeaderSetting('nav_position'),
   site_header__branding_name: getHeaderSetting('site_wide_branding_name')|default('Yale University'),
   site_header__branding_link: getHeaderSetting('site_wide_branding_link')|default('https://www.yale.edu'),
-  primary_nav__items: primary_nav__items,
-  utility_nav__items: utility_nav__items,
   drupal_utility_nav: elements.utility_navigation,
 } %}
   {% block site_header__primary_nav %}


### PR DESCRIPTION
## [YSP-738: Hide hamburger menu if no nav items exist](https://yaleits.atlassian.net/browse/YSP-738)

### Description of work
- Add a new library and JS behavior to hide the hamburger menu button when both utility and primary navigation items are absent.
- Updates `atomic.info.yml` and `atomic.libraries.yml` to register the new script.

### Functional testing steps:
- [x] Ensure that menus either in the primary or utility navigation exist and are enabled
- [x] Ensure that on mobile you see the hamburger menu
- [x] Disable all primary and utility menu items
- [x] Ensure that now on mobile you do not see the hamburger menu
