### PR TITLE
Hotfix: YSP-951: Breadcrumbs not showing more than 2 trails levels

### DIFF
--- a/templates/navigation/ys-breadcrumb-block.html.twig
+++ b/templates/navigation/ys-breadcrumb-block.html.twig
@@ -1,5 +1,3 @@
 {{ attach_library('atomic/breadcrumbs' ) }}
 
-{% include '@organisms/menu/breadcrumbs/yds-breadcrumbs.twig' with {
-	breadcrumbs__trail_level: 2,
-} %}
+{% include '@organisms/menu/breadcrumbs/yds-breadcrumbs.twig' %}


### PR DESCRIPTION
## [Hotfix: YSP-951: Breadcrumbs not showing more than 2 trails levels](https://yaleits.atlassian.net/browse/YSP-951)

### Description of work
- Removed the explicit passing of `breadcrumbs__trail_level` variable from the breadcrumb block template include, as it is no longer needed. 
- Work also done in [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/524)

### Testing steps
- See [Yalesites PR multidev](https://github.com/yalesites-org/yalesites-project/pull/985)