### PR TITLE
YSP-638: Header/Footer pencil icon appears on right side instead of left

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -388,3 +388,12 @@ th.field-label {
   color: var(--gin-color-text); 
 } 
 
+/*
+ * The footer is displaying the contextual menu for admins when it should not.
+ * This hides this from the users while giving us the flexibility to get to it
+ * should we ever need it.
+ */
+#block-yalesitesfooterblock .contextual,
+#block-yalesitesfooterblock .contextual-region {
+  display: none;
+}


### PR DESCRIPTION
## [YSP-638: Header/Footer pencil icon appears on right side instead of left](https://yaleits.atlassian.net/browse/YSP-638)

### Description of work
- Hide the contextual menu and contextual region in the footer block for users, while still allowing access if needed in the future.

### Functional testing steps:
- [x] Log in as a platform admin on the [multidev](https://github.com/yalesites-org/yalesites-project/pull/990)
- [x] Ensure that when viewing a page inside or outside of layout builder you do not see the pencil icon on the footer