### PR TITLE
YSP-568: Improve pagination - too many options

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -57,6 +57,18 @@ function atomic_preprocess_pager(array &$variables) {
 }
 
 /**
+ * Implements hook_theme_suggestions_HOOK_alter() for pager.
+ */
+function atomic_theme_suggestions_pager_alter(array &$suggestions, array $variables) {
+  // Remove gin-lb suggestion(s).
+  foreach ($suggestions as $key => $suggestion) {
+    if ($suggestion === 'pager__gin_lb' || $suggestion === 'pager--gin-lb') {
+      unset($suggestions[$key]);
+    }
+  }
+}
+
+/**
  * Implements hook_theme_suggestions_hook_alter() for containers.
  */
 function atomic_theme_suggestions_container_alter(array &$suggestions, array &$variables) {

--- a/atomic.theme
+++ b/atomic.theme
@@ -45,6 +45,18 @@ function atomic_preprocess_menu(&$variables, $hook) {
 }
 
 /**
+ * Implements hook_preprocess_pager().
+ *
+ * Adds total pages to the pager variables.
+ */
+function atomic_preprocess_pager(array &$variables) {
+  $element = $variables['pager']['#element'];
+  $pager_manager = \Drupal::service('pager.manager');
+  $pager = $pager_manager->getPager($element);
+  $variables['pager']['#total_pages'] = $pager->getTotalPages();
+}
+
+/**
  * Implements hook_theme_suggestions_hook_alter() for containers.
  */
 function atomic_theme_suggestions_container_alter(array &$suggestions, array &$variables) {

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -367,8 +367,21 @@ label.form-required::after, label.js-form-required::after {
   background: var(--color-basic-white);
 }
 
-.media-library-widget-modal .pager__link {
-  color: var(--color-basic-white);
+.media-library-widget-modal .ui-widget-content a {
+  color: var(--color-basic-black);
+}
+
+.media-library-widget-modal .pager__items {
+  font-weight: normal;
+}
+
+.media-library-widget-modal .pager__link.is-active {
+  background: transparent;
+}
+.media-library-widget-modal .pager__link--next:hover,
+.media-library-widget-modal .pager__link--previous:hover {
+  background: transparent;
+  color: var(--color-link-base);
 }
 
 .layout-builder .pager__items {
@@ -380,14 +393,29 @@ label.form-required::after, label.js-form-required::after {
   background: var(--color-basic-white);
 }
 
-.gin--dark-mode .media-library-widget-modal .pager__link {
-  color: var(--gin-color-primary);
-  background-color: transparent;
-}
-
+/* Claro's pager styles are interfering with ours. */
 .pager__item--last .pager__link::after,
 .pager__item--first .pager__link::before,
 .pager__item--next .pager__link::after,
 .pager__item--previous .pager__link::before {
   --background-image: none;
+  display: none;
+}
+
+/*
+ * Dark mode pager style
+ */
+.gin--dark-mode .media-library-widget-modal .pager__link--next:hover,
+.gin--dark-mode .media-library-widget-modal .pager__link--previous:hover {
+  background: transparent;
+  color: var(--color-basic-white);
+}
+
+.gin--dark-mode .media-library-widget-modal .pager__link {
+  color: var(--gin-color-primary);
+  background-color: transparent;
+}
+
+.gin--dark-mode .media-library-widget-modal .pager__link {
+  color: var(--color-basic-white);
 }

--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -351,3 +351,43 @@ label.form-required::after, label.js-form-required::after {
   color: var(--gin-color-danger) !important;
   background: none !important;
 }
+
+/*
+ * Pager styles
+ *
+ * These address using our custom pager with layout builder in certain cases like
+ * media library and layout builder itself.
+ */
+.pager__link.is-active {
+  color: var(--color-basic-brown-gray);
+  border-color: var(--color-basic-brown-gray);
+}
+
+.layout-builder .pager__link.is-active {
+  background: var(--color-basic-white);
+}
+
+.media-library-widget-modal .pager__link {
+  color: var(--color-basic-white);
+}
+
+.layout-builder .pager__items {
+  font-weight: normal;
+}
+
+.layout-builder .pager__items.is-active {
+  background-color: var(--color-basic-white);
+  background: var(--color-basic-white);
+}
+
+.gin--dark-mode .media-library-widget-modal .pager__link {
+  color: var(--gin-color-primary);
+  background-color: transparent;
+}
+
+.pager__item--last .pager__link::after,
+.pager__item--first .pager__link::before,
+.pager__item--next .pager__link::after,
+.pager__item--previous .pager__link::before {
+  --background-image: none;
+}


### PR DESCRIPTION
## [YSP-568: Improve pagination - too many options](https://yaleits.atlassian.net/browse/YSP-568)

### Description of work
- Implement hook_preprocess_pager() in atomic.theme to add the total number of pages to the pager variables.
- Work also completed in [Component Library Twig](https://github.com/yalesites-org/component-library-twig/pull/528) and [Yalesites Project](https://github.com/yalesites-org/yalesites-project/pull/995)
