### PR TITLE
YSP-904: Add Image Background to Action Banner and Callout Blocks

### DIFF
--- a/templates/block/layout-builder/block--inline-block--callout.html.twig
+++ b/templates/block/layout-builder/block--inline-block--callout.html.twig
@@ -4,9 +4,13 @@
   {% embed "@molecules/callout/yds-callout.twig" with {
       callout__background_color: content.field_style_color.0['#markup'],
       callout__alignment: content.field_style_alignment.0['#markup'],
+      callout__overlay_background_image: content.field_overlay_background_image.0,
   } %}
     {% block callout__items %}
       {{ content.field_callout }}
+    {% endblock %}
+    {% block callout__overlay_background_image %}
+      {{ content.field_overlay_background_image }}
     {% endblock %}
   {% endembed %}
 

--- a/templates/block/layout-builder/block--inline-block--cta-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--cta-banner.html.twig
@@ -1,7 +1,6 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
-
   {% embed "@molecules/banner/action/yds-action-banner.twig" with {
     banner__heading: content.field_heading,
     banner__heading__level: content.field_heading_level.0['#markup'],
@@ -13,9 +12,13 @@
     banner__content__background: content.field_style_color.0['#markup'],
     banner__content__layout: content.field_style_position.0['#markup'],
     banner__width: 'site',
+    banner__overlay_background_image: content.field_overlay_background_image.0,
   } %}
     {% block banner__image %}
       {{ content.field_media }}
+    {% endblock %}
+    {% block banner__overlay_background_image %}
+      {{ content.field_overlay_background_image }}
     {% endblock %}
   {% endembed %}
 


### PR DESCRIPTION
## [YSP-904: Add Image Background to Action Banner and Callout Blocks](https://yaleits.atlassian.net/browse/YSP-904)

### Description of work
- Adds overlay background image field support to CTA Banner block template
- Adds overlay background image field support to Callout block template  
- Passes overlay background image field to embedded component templates for enhanced design flexibility
- Renders overlay background image in dedicated blocks for improved layout control

### Functional testing steps:
- [ ] Create a new CTA Banner block in Layout Builder
- [ ] Verify the overlay background image field is available in the block configuration
- [ ] Upload an image to the overlay background image field
- [ ] Save the block and verify the overlay background image renders correctly
- [ ] Test different content background colors to ensure proper overlay functionality
- [ ] Create a new Callout block in Layout Builder  
- [ ] Verify the overlay background image field is available in the callout block configuration
- [ ] Upload an image to the overlay background image field in the callout block
- [ ] Save the callout block and verify the overlay background image renders correctly
- [ ] Test different callout background colors and alignments with overlay images
- [ ] Verify responsive behavior of overlay images on mobile and tablet devices
- [ ] Test accessibility with screen readers to ensure overlay images don't interfere with content readability