### PR TITLE
YSP-948 :: Add Caption Field to Spotlight Blocks (Landscape and Portrait)

### DIFF
--- a/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight-portrait.html.twig
@@ -16,6 +16,8 @@
       content_spotlight_portrait__position: content.field_style_position.0['#markup'],
       content_spotlight_portrait__theme: content.field_style_color.0['#markup'],
       content_spotlight_portrait__vertical_align: content.field_style_alignment.0['#markup'],
+      content_spotlight_portrait__caption: content.field_caption.0,
+      content_spotlight_portrait__image: content.field_media,
   }%}
 
     {% block content_spotlight_portrait__image %}

--- a/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
+++ b/templates/block/layout-builder/block--inline-block--content-spotlight.html.twig
@@ -18,6 +18,8 @@
     text_with_image__width: content.field_style_width.0['#markup'],
     text_with_image__theme: content.field_style_color.0['#markup'],
     text_with_image__vertical_align: content.field_style_alignment.0['#markup'],
+    text_with_image__caption: content.field_caption.0,
+    text_with_image__image: content.field_media,
   } %}
 
     {% block text_with_image__image %}


### PR DESCRIPTION
## [YSP-948: Add Caption Field to Spotlight Blocks (Landscape and Portrait)](https://yaleits.atlassian.net/browse/YSP-948)

### Description of work
- Adjusts templates for spotlight blocks to include caption

### Functional testing steps:
- [ ] Add a spotlight block to a page in layout builder
- [ ]  Verify there is a caption textarea that accepts restricted HTML
- [ ]  Verify the caption displays properly below the image and the color works for all theme variations

Uses platform branch: https://github.com/yalesites-org/yalesites-project/pull/1008
Uses CL branch: https://github.com/yalesites-org/component-library-twig/pull/532