### PR TITLE
YSP-973 :: Taxonomy: Headings start with H2 on Taxonomy pages

### DIFF
--- a/templates/views/views-view-unformatted--taxonomy_term--page_1.html.twig
+++ b/templates/views/views-view-unformatted--taxonomy_term--page_1.html.twig
@@ -8,11 +8,19 @@
     </header>
   {% endif %}
 
+  {% include "@atoms/typography/headings/yds-heading.twig" with {
+    heading__level: '1',
+    heading__blockname: 'page-title',
+    heading: title,
+    heading__attributes: {
+      'data-component-width': 'site',
+    },
+  } %}
+
   {{ attachment_before }}
 
   {% if rows -%}
     {% embed "@organisms/card-collection/yds-card-collection.twig" with {
-      card_collection__heading: title,
       card_collection__featured: 'true',
       card_collection__type: 'list',
       card_collection__width: 'site',


### PR DESCRIPTION
## [YSP-973: Taxonomy: Headings start with H2 on Taxonomy pages](https://yaleits.atlassian.net/browse/YSP-973)

### Description of work
- Removes card collection title from taxonomy page (which is h2)
- Adds an h1 title to the page

### Functional testing steps:
- [ ] Go to a taxonomy page that has content
- [ ] Verify the title is h1 and the page looks as expected
