### PR TITLE
fix(inline-message): remove stray parentheses in inline message block

### DIFF
--- a/templates/block/layout-builder/block--inline-block--inline-message.html.twig
+++ b/templates/block/layout-builder/block--inline-block--inline-message.html.twig
@@ -4,7 +4,7 @@
 
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set inline_message__width = "content" %}
-    {% set inline_message__alignment = "center" %}()
+    {% set inline_message__alignment = "center" %}
   {% else %}
     {% set inline_message__width = "site" %}
     {% set inline_message__alignment = "left" %}


### PR DESCRIPTION

## [YALB-XX: Title](https://yaleits.atlassian.net/browse/YALB-XX)

### Description of work
- Removed an extraneous pair of parentheses from the Twig template variable assignment for `inline_message__alignment` in the inline message block.

### Functional testing steps:
- [ ] Make a post or event
- [ ] Make a in-line message block
- [ ] Ensure on save that you do not see strange parens showing `()`
