### PR TITLE
YSP-1069: Pagination View A11y Changes

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -133,6 +133,47 @@ function atomic_theme_suggestions_field_alter(array &$suggestions, array $variab
 }
 
 /**
+ * Implements hook_preprocess_views_view().
+ *
+ * Adds section wrapper and aria-label for YS Views Basic views.
+ */
+function atomic_preprocess_views_view(&$variables) {
+  $view = $variables['view'];
+
+  // Only process views_basic_scaffold and views_basic_scaffold_events views.
+  if (!in_array($view->id(), ['views_basic_scaffold', 'views_basic_scaffold_events'])) {
+    return;
+  }
+
+  // Content type labels for aria-label.
+  $content_type_labels = [
+    'post' => 'Posts',
+    'event' => 'Events',
+    'page' => 'Pages',
+    'profile' => 'Profiles',
+  ];
+
+  // Default aria-label.
+  $aria_label = 'Content';
+
+  // Extract content type from view arguments if available.
+  if (!empty($view->args)) {
+    // Views basic passes JSON parameters in the arguments.
+    // The content type filter is typically in the first argument.
+    $first_arg = reset($view->args);
+    if ($first_arg && is_string($first_arg)) {
+      if (isset($content_type_labels[$first_arg])) {
+        $aria_label = $content_type_labels[$first_arg] . " collection";
+      }
+    }
+  }
+
+  // Add section wrapper variables.
+  $variables['use_section_wrapper'] = TRUE;
+  $variables['section_aria_label'] = $aria_label;
+}
+
+/**
  * Implements hook_preprocess_HOOK().
  *
  * Attempt to pre-set the main content ID based on whether

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -389,10 +389,11 @@ th.field-label {
 } 
 
 /*
- * The footer is displaying the contextual menu for admins when it should not.
+ * There are places where the contextual menu is showing when it should not.
  * This hides this from the users while giving us the flexibility to get to it
  * should we ever need it.
  */
+#block-atomic-custombooknavigation .contextual,
 #block-yalesitesfooterblock .contextual,
 #block-yalesitesfooterblock .contextual-region {
   display: none;

--- a/templates/views/views-view--views-basic-scaffold-events.html.twig
+++ b/templates/views/views-view--views-basic-scaffold-events.html.twig
@@ -3,7 +3,7 @@
 
 {% set dom_id_class = dom_id ? 'js-view-dom-id-' ~ dom_id %}
 
-<div class={{ dom_id_class }}>
+<section class={{ dom_id_class }} aria-label="{{ section_aria_label }}">
   {{ title_prefix }}
   {{ title }}
   {{ title_suffix }}
@@ -33,4 +33,4 @@
   {% endif %}
 
   {{ feed_icons }}
-</div>
+</section>

--- a/templates/views/views-view--views-basic-scaffold.html.twig
+++ b/templates/views/views-view--views-basic-scaffold.html.twig
@@ -3,7 +3,7 @@
 
 {% set dom_id_class = dom_id ? 'js-view-dom-id-' ~ dom_id %}
 
-<div class={{ dom_id_class }}>
+<section class={{ dom_id_class }} aria-label="{{ section_aria_label }}">
   {{ title_prefix }}
   {{ title }}
   {{ title_suffix }}
@@ -33,4 +33,4 @@
   {% endif %}
 
   {{ feed_icons }}
-</div>
+</section>


### PR DESCRIPTION
## [YSP-1069: Pagination View A11y Changes](https://yaleits.atlassian.net/browse/YSP-1069)

### Description of work
- Adds the ARIA role "group" to the inline block view template for improved accessibility.
- Hide pencil icon for custom collection navigation section

### Functional testing steps:
- [ ] Visit [multidev PR](https://github.com/yalesites-org/yalesites-project/pull/1036)
- [ ] Create a page
- [ ] Create a view
- [ ] Ensure the group role is properly placed at the block level and that a11y traversal and labels make sense
- [ ] Ensure when mousing over the content collection that a pencil icon does not appear on the right side of the block