### PR TITLE
Accessibility RC fixes

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -193,6 +193,11 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
   color: var(--color-blue-light) !important;
 }
 
+/* Ensure chosen selection in dark mode sidebar uses readable text color. */
+.gin--dark-mode #drupal-off-canvas-wrapper a.chosen-single {
+  color: var(--color-basic-black) !important;
+}
+
 /*
 Moderation sidebar
 */


### PR DESCRIPTION
## Accessibility RC fixes

### Description of work
- Ensure that the chosen selection in the dark mode sidebar uses a readable text color by setting it to basic black.
- Other work completed in https://github.com/yalesites-org/yalesites-project/pull/1038

### Functional testing steps:
- [ ] Create a facts and figures block
- [ ] Edit the block
- [ ] Edit the item
- [ ] Ensure that the chosen dropdown now passes contrast
