### PR TITLE
YSP-936 :: Remove Extra Top Padding from Spotlight Blocks in Banner Regions

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -37,18 +37,6 @@ would be used instead resulting in top margin of size-spacing-6.  */
   margin-bottom: 0;
 }
 
-/* We allow spotlights in the banner now, but they appear a little to close to
- * the top of the page. This allows us to adjust the top margin to give a
- * little more space to just the first one.
- */
-.main-content .layout--banner .layout__region > .text-with-image:first-child,
-.main-content
-  .layout--banner
-  .layout__region
-  > .content-spotlight-portrait:first-child {
-  margin-top: var(--size-spacing-8);
-}
-
 /* The last item inside the `.main-content` area should have some space between
 // it and the site footer (size-spacing-12 below) - unless it is designated as
 // `$flush-bottom` above. Then it will have no bottom-margin separating it from
@@ -379,14 +367,14 @@ th.field-label {
  * gin, and ckeditor.
  */
 .gin--dark-mode .field-multiple-table.glb-table tr.draggable > td {
-  background-color: var(--gin-bg-layer); 
-  color: var(--gin-color-text); 
-} 
+  background-color: var(--gin-bg-layer);
+  color: var(--gin-color-text);
+}
 
-.gin--dark-mode .field-multiple-table.glb-table tr.draggable:nth-child(odd) > td { 
-  background-color: var(--gin-bg-layer2); 
-  color: var(--gin-color-text); 
-} 
+.gin--dark-mode .field-multiple-table.glb-table tr.draggable:nth-child(odd) > td {
+  background-color: var(--gin-bg-layer2);
+  color: var(--gin-color-text);
+}
 
 /*
  * There are places where the contextual menu is showing when it should not.


### PR DESCRIPTION
## [YSP-936: Remove Extra Top Padding from Spotlight Blocks in Banner Regions](https://yaleits.atlassian.net/browse/YSP-936)

### Description of work
- Remove top padding from spotlights in banner region.

### Functional testing steps:
- [ ] Add spotlight block to the banner region of a page. Verify it has no additional padding.

Demo: https://pr-1073-yalesites-platform.pantheonsite.io/spotlight-in-banner-region-test
