### PR TITLE
YSP-1154: RC: Resource Content Type is not showing in site search

### DIFF
--- a/templates/node/node--resource--search-result.html.twig
+++ b/templates/node/node--resource--search-result.html.twig
@@ -1,0 +1,1 @@
+{% include "@atomic/templates/node/node--search-result.html.twig" %}


### PR DESCRIPTION
## [YSP-1154: RC: Resource Content Type is not showing in site search](https://yaleits.atlassian.net/browse/YSP-1154)

### Description of work
- Added node--resource--search-result.html.twig to support resource nodes in search results.

### Functional testing steps:
- [ ] Create a resource in the multidev PR
- [ ] Search for that resource
- [ ] Ensure that it is properly styled
