### PR TITLE
YSP-902: Restructure Block Forms into Three Logical Tabs

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -448,6 +448,13 @@ th.field-label {
   max-width: 100% !important;
 }
 
+/* Fix tab border alignment in Layout Builder (YSP-902) */
+/* Remove the bottom border from the tabs navigation to eliminate double border */
+#drupal-off-canvas-wrapper .horizontal-tabs ul.horizontal-tabs-list::after,
+.layout-builder-configure-block .horizontal-tabs ul.horizontal-tabs-list::after {
+  border-bottom: none !important;
+}
+
 /* Ensure the tab content wrapper takes full available width in sidebar */
 .horizontal-tabs-pane.glb-claro-details .glb-claro-details__wrapper.details-wrapper {
   width: 100%;


### PR DESCRIPTION
## [YSP-902: Restructure Block Forms into Three Logical Tabs](https://yaleits.atlassian.net/browse/YSP-902)

### Description of work
- Fixes tab content overflow issues in Layout Builder block forms where content was extending beyond the white border of the tab container
- Resolves double border display issue on Layout Builder tabs by removing duplicate bottom border from tab navigation
- Improves tab width handling in the edit block sidebar to prevent overflow and ensure proper containment
- Adds proper box-sizing and overflow containment for Gin Layout Builder form elements within horizontal tabs
- Other work completed in https://github.com/yalesites-org/yalesites-project/pull/1097

### Functional testing steps:
- [ ] Navigate to Layout Builder on any page with blocks
- [ ] Click to edit an existing block that has tabbed form interface
- [ ] Verify that tab content stays within the white border boundaries (no overflow)
- [ ] Check that there is no double border line between the tab navigation and content area
- [ ] Test the edit block sidebar functionality to ensure tabs display at full width without overflow
- [ ] Verify form elements within tabs are properly contained and don't extend beyond tab boundaries
- [ ] Test both the modal block configuration and the sidebar block edit interfaces
- [ ] Confirm the fixes work across different block types that use the tabbed interface