### PR TITLE
feat(YSP-822): add end date and format logic to event cards

### DIFF
--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -17,9 +17,24 @@
   {% endset %}
 {% endif %}
 
+{# Used to test if we're ouputting for the same day or multiple days #}
+{% set start_date = content.field_event_date[delta].start_time['#markup']|date('Y-m-d') %}
+{% set end_date = content.field_event_date[delta].end_time['#markup']|date('Y-m-d') %}
+
+{% set same_day = start_date == end_date %}
+{{ same_day ? "yes" : "no"}}
+
+{# Determine the date format based on whether the event starts and ends on the same day #}
+{% set date_time__format = 'date_time_multiple_days' %}
+{% if same_day %}
+  {% set date_time__format = 'same_day_diff_time' %}
+{% endif %}
+
 {% set date__formatted %}
   {% include "@atoms/date-time/yds-date-time.twig" with {
     date_time__start: content.field_event_date[delta].start_time['#markup'],
+    date_time__end: content.field_event_date[delta].end_time['#markup'],
+    date_time__format: date_time__format,
   } %} {{multi_day_text}}
 {% endset %}
 

--- a/templates/node/node--event--condensed.html.twig
+++ b/templates/node/node--event--condensed.html.twig
@@ -23,9 +23,23 @@
 {# Set the event title prefix based on event status #}
 {% set event_title__prefix = event_has_passed ? 'Past Event: ' : '' %}
 
+{# Used to test if we're ouputting for the same day or multiple days #}
+{% set start_date = content.field_event_date[delta].start_time['#markup']|date('Y-m-d') %}
+{% set end_date = content.field_event_date[delta].end_time['#markup']|date('Y-m-d') %}
+
+{% set same_day = start_date == end_date %}
+
+{# Determine the date format based on whether the event starts and ends on the same day #}
+{% set date_time__format = 'date_time_multiple_days' %}
+{% if same_day %}
+  {% set date_time__format = 'same_day_diff_time' %}
+{% endif %}
+
 {% set date__formatted %}
   {% include "@atoms/date-time/yds-date-time.twig" with {
     date_time__start: content.field_event_date[delta].start_time['#markup'],
+    date_time__end: content.field_event_date[delta].end_time['#markup'],
+    date_time__format: date_time__format,
   } %} {{multi_day_text}}
 {% endset %}
 

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -16,9 +16,28 @@
   {% endset %}
 {% endif %}
 
+{# Used to test if we're ouputting for the same day or multiple days #}
+{% set start_date = content.field_event_date[delta].start_time['#markup']|date('Y-m-d') %}
+{% set end_date = content.field_event_date[delta].end_time['#markup']|date('Y-m-d') %}
+
+{% set same_day = start_date == end_date %}
+
+{# Determine the date format based on whether the event starts and ends on the same day #}
+{% set date_time__format = 'date_time_multiple_days' %}
+{% if same_day %}
+  {% set date_time__format = 'same_day_diff_time' %}
+{% endif %}
+  {# Override the date format if the event spans multiple days #}
+{# {% set date_time__format = 'same_day_diff_time' %} #}
+{# {% if start_date != end_date %} #}
+{#   {% set date_time__format = 'date_time_multiple_days' %} #}
+{# {% endif %} #}
+
 {% set date__formatted %}
   {% include "@atoms/date-time/yds-date-time.twig" with {
     date_time__start: content.field_event_date[delta].start_time['#markup'],
+    date_time__end: content.field_event_date[delta].end_time['#markup'],
+    date_time__format: date_time__format,
   } %} {{ multi_day_text }}
 {% endset %}
 


### PR DESCRIPTION
## [YSP-822: Add Event Time to Event Display Modes](https://yaleits.atlassian.net/browse/YSP-822)

### Description of work
- Enhanced event display templates to intelligently format date/time based on event duration
- Added logic to determine if events occur on the same day vs. multiple days
- Updated three event display modes (card, condensed, list-item) to include end times and appropriate formatting
- Implemented dynamic date format selection using same_day_diff_time for single-day events and
date_time_multiple_days for multi-day events

### Functional testing steps:
- [ ] Create a single-day event (same start and end date) and verify it displays with same_day_diff_time format
- [ ] Create a multi-day event (different start and end dates) and verify it displays with date_time_multiple_days
format
- [ ] Test event card display mode shows correct date/time formatting
- [ ] Test event condensed display mode shows correct date/time formatting
- [ ] Test event list-item display mode shows correct date/time formatting
- [ ] Verify both start and end times are properly displayed for all event types
- [ ] Confirm the date format logic correctly identifies same-day vs multi-day events using Y-m-d comparison

