### PR TITLE
YSP-970 :: Can't drag and drop video block between columns in the same section

### DIFF
--- a/templates/block/layout-builder/block--inline-block--video.html.twig
+++ b/templates/block/layout-builder/block--inline-block--video.html.twig
@@ -18,7 +18,11 @@
   } %}
 
     {% block video__video %}
-      {{ content.field_media }}
+      <div class="video-container" data-video-isolated="true">
+        <div class="video-content-wrapper">
+          {{ content.field_media }}
+        </div>
+      </div>
     {% endblock %}
 
   {% endembed %}


### PR DESCRIPTION
## [YSP-970: Can't drag and drop video block between columns in the same section](https://yaleits.atlassian.net/browse/YSP-970)

### Description of work
- Adds video wrapper that allows targeting with css to ensure video can be drag and dropped

Functional testing steps:
 Add a video block to a region that has multiple sections (50-50, 33-33-33, 70-30). Verify you can drag videos between sections. Verify the video plays properly when not in LB context.

Platform (demo) PR: https://github.com/yalesites-org/yalesites-project/pull/1106
Component Library PR: https://github.com/yalesites-org/component-library-twig/pull/580