### PR TITLE
fix(YSP-1052): improve table contrast in dark mode

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -332,15 +332,6 @@ blockquote.pull-quote__quote::before {
 }
 
 /*
- * Move table contrast fix for dark mode.
- */
-html.gin--dark-mode .layout-builder-components-table tr td .tabledrag-toggle-weight,
-html.gin--dark-mode .layout-builder-components-table tr:hover td,
-html.gin--dark-mode .layout-builder-components-table tr:nth-child(even) td {
-  color: var(--color-white);
-}
-
-/*
 * Fix cancel button color in gin
 */
 html.gin--dark-mode .button.dialog-cancel {

--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -196,15 +196,10 @@ div[data-drupal-selector="edit-block-form"] {
   padding: 1rem;
 }
 
-.layout-builder-components-table th {
-  background-color: transparent;
-  border: none;
-}
-
-.layout-builder-components-table tr:nth-child(2n) {
+.layout-builder-components-table tr:nth-child(odd) {
   background-color: var(--gin-bg-layer);
+  color: var(--gin-color-text);
 }
-
 
 #drupal-off-canvas-wrapper .draggable:hover,
 #drupal-off-canvas-wrapper .draggable:focus-within {


### PR DESCRIPTION

## [YSP-1052: Fix 'move' right side bar again](https://yaleits.atlassian.net/browse/YSP-1052)

### Description of work
- Removes redundant dark mode table contrast styles from admin-theme.css and updates layout-builder.css to apply correct background and text color for odd table rows in dark mode.

### Functional testing steps:
- [ ] Go into layout builder on a node
- [ ] Use the edit icon on a block, and select "Move"
- [ ] Ensure that all sidebar items are easily visible
