### PR TITLE
438: Reduce Font Size Past Event Date Labels

### DIFF
--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -1,5 +1,3 @@
-{% set event_has_passed = event_dates is empty %}
-
 {# Use event_dates array to print any event dates - look inside array for formatted options #}
 
 {% set delta = 0 %}
@@ -7,6 +5,8 @@
 {% if elements['#delta'] is not empty %}
   {% set delta = elements['#delta'] %}
 {% endif %}
+
+{% set event_has_passed = content.field_event_date[delta].end_time['#markup']|date("U") < "now"|date("U") %}
 
 {% if event_dates|length > 1 %}
   {% set multi_day_text %}
@@ -49,13 +49,10 @@
 
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
-{# Set the event title prefix based on event status #}
-{% set event_title__prefix = event_has_passed ? 'Past Event: ' : '' %}
-
 {# field_ticket_registration_url #}
 {# field_external_source #}
 {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
-  reference_card__prefix: event_title__prefix,
+  event_has_passed: event_has_passed,
   reference_card__heading: heading,
   reference_card__subheading: date__formatted,
   reference_card__url: url,

--- a/templates/node/node--event--condensed.html.twig
+++ b/templates/node/node--event--condensed.html.twig
@@ -14,14 +14,11 @@
   {% endset %}
 {% endif %}
 
-{% set event_has_passed = event_dates is empty %}
+{% set event_has_passed = content.field_event_date[delta].end_time['#markup']|date("U") < "now"|date("U") %}
 
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 {% set reference_card__image = 'false' %}
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
-
-{# Set the event title prefix based on event status #}
-{% set event_title__prefix = event_has_passed ? 'Past Event: ' : '' %}
 
 {# Used to test if we're ouputting for the same day or multiple days #}
 {% set start_date = content.field_event_date[delta].start_time['#markup']|date('Y-m-d') %}
@@ -44,7 +41,7 @@
 {% endset %}
 
 {% include "@molecules/cards/reference-card/yds-reference-card.twig" with {
-  reference_card__prefix: event_title__prefix,
+  event_has_passed: event_has_passed,
   reference_card__heading: heading,
   reference_card__subheading: date__formatted,
   reference_card__url: url,

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -4,7 +4,7 @@
   {% set delta = elements['#delta'] %}
 {% endif %}
 
-{% set event_has_passed = event_dates is empty %}
+{% set event_has_passed = content.field_event_date[delta].end_time['#markup']|date("U") < "now"|date("U") %}
 
 {# Use event_dates array to print any event dates - look inside array for formatted options #}
 {% if event_dates|length > 1 %}
@@ -52,11 +52,8 @@
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
-{# Set the event title prefix based on event status #}
-{% set event_title__prefix = event_has_passed ? 'Past Event: ' : '' %}
-
 {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
-  reference_card__prefix: event_title__prefix,
+  event_has_passed: event_has_passed,
   reference_card__heading: heading,
   reference_card__subheading: date__formatted,
   reference_card__url: url,

--- a/templates/node/node--event--single.html.twig
+++ b/templates/node/node--event--single.html.twig
@@ -6,6 +6,8 @@
   {% set delta = elements['#delta'] %}
 {% endif %}
 
+{% set event_has_passed = content.field_event_date.0['#value'] < "now"|date("U") %}
+
 {% set date__formatted %}
   {% include "@atoms/date-time/yds-date-time.twig" with {
     date_time__start: content.field_event_date[delta].start_time['#markup']|default(content.field_event_date.0['#value']),
@@ -25,6 +27,7 @@
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
 {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  event_has_passed: event_has_passed,
   reference_card__heading: heading,
   reference_card__subheading: date__formatted,
   reference_card__url: url,

--- a/templates/node/node--view--taxonomy-term.html.twig
+++ b/templates/node/node--view--taxonomy-term.html.twig
@@ -14,12 +14,12 @@
 {# For events, include event-specific formatting #}
 {% if node.getType() == 'event' %}
   {% set delta = 0 %}
-  
+
   {% if elements['#delta'] is not empty %}
     {% set delta = elements['#delta'] %}
   {% endif %}
-  
-  {% set event_has_passed = event_dates is empty %}
+
+  {% set event_has_passed = content.field_event_date[delta].end_time['#markup']|date("U") < "now"|date("U") %}
   
   {# Use event_dates array to print any event dates #}
   {% if event_dates|length > 1 %}
@@ -44,9 +44,6 @@
       } %}
     {%- endset %}
   {% endif %}
-
-  {# Set the event title prefix based on event status #}
-  {% set event_title__prefix = event_has_passed ? 'Past Event: ' : '' %}
 {% endif %}
 
 {# Build the reference card parameters based on content type #}
@@ -71,7 +68,7 @@
   }) %}
 {% elseif node.getType() == 'event' %}
   {% set reference_card_params = reference_card_params|merge({
-    reference_card__prefix: event_title__prefix,
+    event_has_passed: event_has_passed,
     reference_card__subheading: date__formatted,
     reference_card__snippet: content.field_teaser_text,
     reference_card__cta_primary__href: ticket_url,


### PR DESCRIPTION
## [438: Reduce Font Size Past Event Date Labels](https://github.com/yalesites-org/YaleSites-Internal/issues/438)

### Description of work
- Removes "Past Event:" text prefix from event card titles
- Updates past event detection to use per-date timestamp comparison
- Changes event templates to pass `event_has_passed` boolean flag
- Applies changes across card, condensed, list-item, single, and taxonomy-term views
- Improves past event indication using component-level styling
- Other work completed in:
  - Component Library Twig: https://github.com/yalesites-org/component-library-twig/pull/586

### Functional testing steps:
- [ ] Test all in [multidev](https://github.com/yalesites-org/yalesites-project/pull/1123)
- [ ] Verify past event cards show clock icon instead of text prefix
- [ ] Check condensed event view displays clock icon correctly
- [ ] Test list-item event view shows clock icon for past dates
- [ ] Confirm icon appears for multi-day events with past dates
- [ ] Verify icon is properly decorative (no accessibility issues)