### PR TITLE
833: Tiles: Adding a link with no content results in no link displayed

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -94,3 +94,6 @@ ys_embed:
 read-time:
   js:
     node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/read-time/yds-read-time.js: {}
+tile-item:
+  js:
+    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/tile-item/yds-tile-item.js: {}

--- a/templates/block/layout-builder/block--inline-block--tiles.html.twig
+++ b/templates/block/layout-builder/block--inline-block--tiles.html.twig
@@ -2,6 +2,7 @@
 
 {% block content %}
   {{ attach_library('atomic/spotlights') }}
+  {{ attach_library('atomic/tile-item') }}
 
   {% embed "@organisms/tiles/yds-tiles.twig" with {
     tiles__alignment: content.field_style_alignment.0['#markup'],


### PR DESCRIPTION
## [833: Tiles: Adding a link with no content results in no link displayed](https://github.com/yalesites-org/YaleSites-Internal/issues/833)

### Description of work
- Adds tile-item JavaScript library to enable clickable tiles
- Fixes missing JavaScript behavior for tile link interactions
- Attaches tile-item library to tiles block template
- Work also completed in https://github.com/yalesites-org/component-library-twig/pull/592

### Functional testing steps:
- [ ] Create a tiles block with multiple tile items
- [ ] Add links to tile items (heading links or content links)
- [ ] Verify clicking anywhere on the tile background activates the link
- [ ] Test that text selection still works (clicks longer than 200ms)
- [ ] Confirm tiles without links remain non-clickable
- [ ] Test with different tile configurations (with/without images, different themes)
