### PR TITLE
1005 :: Add Design Option for Link Grid Line Treatment

### DIFF
--- a/templates/block/layout-builder/block--inline-block--link-grid.html.twig
+++ b/templates/block/layout-builder/block--inline-block--link-grid.html.twig
@@ -20,9 +20,12 @@
   {% set link_grid__links_three = content.field_link_lists.2 %}
   {% set link_grid__links_four = content.field_link_lists.3 %}
 
+  {% set link_grid__line_treatment = link_grid__line_treatment|default('default') %}
+
   {% embed "@molecules/link-grid/yds-link-grid.twig" with {
     link_grid__theme: link_grid_theme,
     link_grid__heading: content.field_heading.0,
+    link_grid__line_treatment: link_grid__line_treatment,
   }%}
     {% block link_grid__links_one %}
       {{content.field_link_lists.0}}


### PR DESCRIPTION
## [1005: Add Design Option for Link Grid Line Treatment](https://github.com/yalesites-org/YaleSites-Internal/issues/1005)

### Description of work
- Adds Line Treatment option to Link Grid block
- Adds template variable and scss to apply line treatment
- Adds a control to storybook to demo the line treatment

### Functional Review Steps
- [ ] Verify there is a Line Treatment select field on the Link Grid block (see ticket)
- [ ] Verify when you update the Line Treatment, the lines on the block are updated as expected
- [ ] Verify when you update the Storybook control for line treatment for this component it appears as expected

Platform PR: https://github.com/yalesites-org/yalesites-project/pull/1169
CL PR: https://github.com/yalesites-org/component-library-twig/pull/601
