### PR TITLE
#1122 :: Remove "Multi-Day Event" Label from Views/Listing Block Results

### DIFF
--- a/templates/node/node--event--card.html.twig
+++ b/templates/node/node--event--card.html.twig
@@ -8,15 +8,6 @@
 
 {% set event_has_passed = content.field_event_date[delta].end_time['#markup']|date("U") < "now"|date("U") %}
 
-{% if event_dates|length > 1 %}
-  {% set multi_day_text %}
-    {% include "@atoms/typography/text/yds-text.twig" with {
-      text__base_class: 'multi-day-event',
-      text__content: '(multi-day event)',
-    } %}
-  {% endset %}
-{% endif %}
-
 {# Used to test if we're ouputting for the same day or multiple days #}
 {% set start_date = content.field_event_date[delta].start_time['#markup']|date('Y-m-d') %}
 {% set end_date = content.field_event_date[delta].end_time['#markup']|date('Y-m-d') %}
@@ -40,7 +31,7 @@
     date_time__end: content.field_event_date[delta].end_time['#markup'],
     date_time__format: date_time__format,
     date_time__all_day: is_all_day,
-  } %} {{multi_day_text}}
+  } %}
 {% endset %}
 
 {% if content.field_localist_event_experience.0 %}

--- a/templates/node/node--event--condensed.html.twig
+++ b/templates/node/node--event--condensed.html.twig
@@ -5,15 +5,6 @@
 {% endif %}
 
 {# Use event_dates array to print any event dates - look inside array for formatted options #}
-{% if event_dates|length > 1 %}
-  {% set multi_day_text %}
-    {% include "@atoms/typography/text/yds-text.twig" with {
-      text__base_class: 'multi-day-event',
-      text__content: '(multi-day event)',
-    } %}
-  {% endset %}
-{% endif %}
-
 {% set event_has_passed = content.field_event_date[delta].end_time['#markup']|date("U") < "now"|date("U") %}
 
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
@@ -43,7 +34,7 @@
     date_time__end: content.field_event_date[delta].end_time['#markup'],
     date_time__format: date_time__format,
     date_time__all_day: is_all_day,
-  } %} {{multi_day_text}}
+  } %}
 {% endset %}
 
 {% include "@molecules/cards/reference-card/yds-reference-card.twig" with {

--- a/templates/node/node--event--list-item.html.twig
+++ b/templates/node/node--event--list-item.html.twig
@@ -7,15 +7,6 @@
 {% set event_has_passed = content.field_event_date[delta].end_time['#markup']|date("U") < "now"|date("U") %}
 
 {# Use event_dates array to print any event dates - look inside array for formatted options #}
-{% if event_dates|length > 1 %}
-  {% set multi_day_text %}
-    {% include "@atoms/typography/text/yds-text.twig" with {
-      text__base_class: 'multi-day-event',
-      text__content: '(multi-day event)',
-    } %}
-  {% endset %}
-{% endif %}
-
 {# Used to test if we're ouputting for the same day or multiple days #}
 {% set start_date = content.field_event_date[delta].start_time['#markup']|date('Y-m-d') %}
 {% set end_date = content.field_event_date[delta].end_time['#markup']|date('Y-m-d') %}
@@ -44,7 +35,7 @@
     date_time__end: content.field_event_date[delta].end_time['#markup'],
     date_time__format: date_time__format,
     date_time__all_day: is_all_day,
-  } %} {{ multi_day_text }}
+  } %}
 {% endset %}
 
 {% if content.field_localist_event_experience.0 %}

--- a/templates/node/node--view--taxonomy-term.html.twig
+++ b/templates/node/node--view--taxonomy-term.html.twig
@@ -20,21 +20,11 @@
   {% endif %}
 
   {% set event_has_passed = content.field_event_date[delta].end_time['#markup']|date("U") < "now"|date("U") %}
-  
-  {# Use event_dates array to print any event dates #}
-  {% if event_dates|length > 1 %}
-    {% set multi_day_text %}
-      {% include "@atoms/typography/text/yds-text.twig" with {
-        text__base_class: 'multi-day-event',
-        text__content: '(multi-day event)',
-      } %}
-    {% endset %}
-  {% endif %}
 
   {% set date__formatted %}
     {% include "@atoms/date-time/yds-date-time.twig" with {
       date_time__start: content.field_event_date[delta].start_time['#markup'],
-    } %} {{ multi_day_text }}
+    } %}
   {% endset %}
 
   {% if content.field_localist_event_experience.0 %}


### PR DESCRIPTION
## [#1122: Remove "Multi-Day Event" Label from Views/Listing Block Results](https://github.com/yalesites-org/YaleSites-Internal/issues/1122)

### Description of work
- Remove multi-day event label from event templates

### Functional testing steps:
### Functional testing steps:
- [ ] Demo: https://pr-1230-yalesites-platform.pantheonsite.io/event-cards-demo
- [ ] Compare to dev: https://dev-yalesites-platform.pantheonsite.io/event-cards-demo
- [ ] Check all of the view modes (Card, List, Condensed)

Demo PR: https://github.com/yalesites-org/yalesites-project/pull/1230
