### PR TITLE
#1140 :: Support Portrait Images in Resource Category View Block

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -128,20 +128,35 @@ function atomic_preprocess_node(&$variables) {
       $variables['date_formatted'] = \Drupal::service('date.formatter')->format($date, '', 'c');
     }
   }
-  
-  // Handle resource thumbnail processing (moved from atomic_preprocess_node__resource)
+  // Handle resource thumbnail processing.
   if ($variables['node']->getType() === 'resource') {
     $view_mode = $variables['elements']['#view_mode'] ?? 'default';
-    
-    // Skip for search_result view mode as it's not needed
+    $responsive_image_style_id = $view_mode === 'portrait_grid'
+      ? 'card_grid_portrait_5_8'
+      : 'resource_thumbnail';
+
+    // Skip for search_result view mode as it's not needed.
     if ($view_mode === 'search_result') {
       return;
     }
-    
+
     /** @var \Drupal\node\Entity\Node $node */
     $node = $variables['node'];
+    $fieldTeaserMedia = $node?->field_teaser_media;
     $fieldMedia = $node?->field_media;
-    
+
+    if ($view_mode === 'portrait_grid' && $fieldTeaserMedia && !$fieldTeaserMedia->isEmpty()) {
+      /** @var \Drupal\media\Entity\Media $teaser_media */
+      $teaser_media = $fieldTeaserMedia->entity;
+      if ($teaser_media) {
+        $variables['content']['field_teaser_media'] = [
+          0 => \Drupal::entityTypeManager()
+            ->getViewBuilder('media')
+            ->view($teaser_media, 'card_grid_portrait_5_8'),
+        ];
+      }
+    }
+
     if (!$fieldMedia) {
       return;
     }
@@ -150,7 +165,7 @@ function atomic_preprocess_node(&$variables) {
     $referenced_entities = $fieldMedia?->referencedEntities() ?? [];
     $media = reset($referenced_entities);
     $thumbnail = $media?->thumbnail;
-      
+
     if (!$thumbnail) {
       return;
     }
@@ -167,7 +182,7 @@ function atomic_preprocess_node(&$variables) {
     $variables['responsive_media_thumbnail'] = [
       '#theme' => 'responsive_image',
       '#uri' => $file->getFileUri(),
-      '#responsive_image_style_id' => 'resource_thumbnail',
+      '#responsive_image_style_id' => $responsive_image_style_id,
       '#height' => $thumbnail?->height,
       '#width' => $thumbnail?->width,
       '#attributes' => [

--- a/templates/node/node--resource--portrait-grid.html.twig
+++ b/templates/node/node--resource--portrait-grid.html.twig
@@ -1,0 +1,49 @@
+{#
+/**
+ * Available Variables:
+ * - responsive_media_thumbnail: A responsive image using the thumbnail file.
+ * - date_formatted: The publish_date in ISO 8601 format.
+ *
+ * @see atomic_preprocess_node()
+ #}
+
+{% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
+{% set date_format = content.field_date_format.0 ? content.field_date_format.0['#markup'] : '' %}
+{% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
+
+{% set publish_date %}
+  {% if date_format %}
+    <strong>{{ 'Published'|t }}:</strong>
+    {% include "@atoms/date-time/yds-date-time.twig" with {
+      date_time__start: date_formatted,
+      date_time__format: date_format,
+    } %}
+  {% endif %}
+{% endset %}
+
+{% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
+  reference_card__heading: heading,
+  reference_card__url: url,
+  reference_card__overline: publish_date,
+  reference_card__image: node.show_thumbnail ? 'true' : 'false',
+  reference_card__snippet: content.field_teaser_text,
+  reference_card__image_aria: heading[0]['#context'].value,
+  reference_card__overlay: node.pin_label,
+  show_categories: node.show_category,
+} %}
+  {% block reference_card__categories %}
+    {{ content.field_category }}
+  {% endblock %}
+
+  {% block reference_card__image %}
+    {% if content.field_teaser_media[0] %}
+      {{ content.field_teaser_media }}
+
+    {% elseif responsive_media_thumbnail %}
+      {{ responsive_media_thumbnail }}
+
+    {% elseif getCoreSetting('image_fallback.teaser') %}
+      {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_grid_portrait_5_8') }}
+    {% endif %}
+  {% endblock %}
+{% endembed %}


### PR DESCRIPTION
## [#1140: Support Portrait Images in Resource Category View Block](https://github.com/yalesites-org/YaleSites-Internal/issues/1140)

### Description of work
- Adds template and preprocess for resource portrait

### Functional testing steps:
- [ ] Add a Resource View to a page, select Portrait Grid. Verify it appears as expected.
- [ ] Verify the option appears in Storybook

CL PR: https://github.com/yalesites-org/component-library-twig/pull/628
Platform PR: https://github.com/yalesites-org/yalesites-project/pull/1238