### PR TITLE
717: Add warning alert to pre-built form block for users with default site email

### DIFF
--- a/templates/block/layout-builder/block--inline-block--webform.html.twig
+++ b/templates/block/layout-builder/block--inline-block--webform.html.twig
@@ -12,8 +12,10 @@
         {% include "@molecules/inline-message/yds-inline-message.twig" with {
             inline_message__heading: "Configuration issue",
             inline_message__content: content['#configuration_issue'],
-            inline_message__type: 'info',
+            inline_message__type: 'general',
             inline_message__theme: 'two',
+            inline_message__link__content: content['#configuration_issue_link_content'],
+            inline_message__link__url: content['#configuration_issue_link_url'],
           } %}
       {% endif %}
 

--- a/templates/block/layout-builder/block--inline-block--webform.html.twig
+++ b/templates/block/layout-builder/block--inline-block--webform.html.twig
@@ -8,17 +8,6 @@
   } %}
 
     {% block component_wrapper_inner %}
-      {% if content['#configuration_issue'] %}
-        {% include "@molecules/inline-message/yds-inline-message.twig" with {
-            inline_message__heading: "Configuration issue",
-            inline_message__content: content['#configuration_issue'],
-            inline_message__type: 'general',
-            inline_message__theme: 'two',
-            inline_message__link__content: content['#configuration_issue_link_content'],
-            inline_message__link__url: content['#configuration_issue_link_url'],
-          } %}
-      {% endif %}
-
       {{content.field_form}}
     {% endblock %}
 


### PR DESCRIPTION
## [717: Add warning alert to pre-built form block for users with default site email](https://github.com/yalesites-org/YaleSites-Internal/issues/717)

### Description of work
- Removes the configuration issue inline-message from the webform block Layout Builder preview template, since the warning in the block configuration form already covers both inline and reusable blocks universally
- Other work completed in: yalesites-org/yalesites-project#1240

### Functional testing steps:
- [ ] Set site email to `noreply@noreply.yale.edu`
- [ ] Add an inline webform block in Layout Builder — confirm the warning appears in the config form sidebar but NOT in the block preview
- [ ] Add/use a reusable webform block — confirm the same: warning in config form, no inline-message in preview
- [ ] Set site email to a real address — confirm no warning appears in either location