### PR TITLE
#1153 :: Color palette: remove ONHA if-statement overrides & add 6th color slot system-wide

### DIFF
--- a/templates/block/layout-builder/block--inline-block--link-grid.html.twig
+++ b/templates/block/layout-builder/block--inline-block--link-grid.html.twig
@@ -8,11 +8,7 @@
     {% set link_grid__width = "site" %}
   {% endif %}
 
-  {% if layout_section == 'ys_layout_two_column_50_50' %}
-    {% set link_grid_theme = 'inherit' %}
-  {% else %}
-    {% set link_grid_theme = content.field_style_color.0['#markup'] %}
-  {% endif %}
+  {% set link_grid_theme = content.field_style_color.0['#markup'] %}
 
   {# add checks for each link list #}
   {% set link_grid__links_one = content.field_link_lists.0 %}

--- a/templates/form/form-element-label--ys-themes-settings-form--global-theme.html.twig
+++ b/templates/form/form-element-label--ys-themes-settings-form--global-theme.html.twig
@@ -12,8 +12,10 @@
   <label{{ attributes.addClass(classes) }}>
     {{ title }}
     <span class="colors">
-      {% for key,value in getSettingValues('global_theme') %}
-        <span class="color" style="background: var(--global-themes-{{ element['#context']['value'] }}-colors-slot-{{ key }});"></span>
+      {# Six selectable palette colors: slots one–five plus slot-nine (secondary background). #}
+      {% set palette_slots = ['one', 'two', 'three', 'four', 'five', 'nine'] %}
+      {% for slot in palette_slots %}
+        <span class="color" style="background: var(--global-themes-{{ element['#context']['value'] }}-colors-slot-{{ slot }});"></span>
       {% endfor %}
     </span>
   </label>


### PR DESCRIPTION
## [#1153: Color palette: remove ONHA if-statement overrides & add 6th color slot system-wide](https://github.com/yalesites-org/YaleSites-Internal/issues/1153)

### Description of work
- Update link grid template to allow it to display its theme color in 50/50

### Functional testing steps:
- [ ] Verify if you select a color for link grid in 50/50, it displays that color as the highlight
