### PR TITLE
1221: RC: Resource View Portrait Grid missing field display options

### DIFF
--- a/templates/node/node--resource--portrait-grid.html.twig
+++ b/templates/node/node--resource--portrait-grid.html.twig
@@ -3,9 +3,12 @@
  * Available Variables:
  * - responsive_media_thumbnail: A responsive image using the thumbnail file.
  * - date_formatted: The publish_date in ISO 8601 format.
+ * - resource_authors: Array of authors, each with 'label' and 'url' keys.
+ * - show_tags: Whether to render tags (set per-block by ys_views_content_resources).
  *
  * @see atomic_preprocess_node()
- #}
+ * @see atomic_preprocess_node__resource()
+#}
 
 {% set heading = content.field_teaser_title.0 ? content.field_teaser_title : label %}
 {% set date_format = content.field_date_format.0 ? content.field_date_format.0['#markup'] : '' %}
@@ -13,7 +16,6 @@
 
 {% set publish_date %}
   {% if date_format %}
-    <strong>{{ 'Published'|t }}:</strong>
     {% include "@atoms/date-time/yds-date-time.twig" with {
       date_time__start: date_formatted,
       date_time__format: date_format,
@@ -21,27 +23,110 @@
   {% endif %}
 {% endset %}
 
+{# Authors — comma-separated. Affiliated authors link to their profile node;
+   non-affiliated authors (no profile, url is NULL) render as plain text. #}
+{% set authors %}
+  {% if resource_authors|length %}
+    <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
+    {% for author in resource_authors %}
+      {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endset %}
+
+{# Combine published date, optional teaser text, and authors into one block.
+   Wrapping in a single outer div prevents the molecule's flex-child pipe separator
+   (`.reference-card__subheading > *:not(:first-child)::before { content: '|' }`) from
+   appearing between them. Tags render via the reference_card__tags block below
+   (matches post / event / page / profile cards). #}
+{% set date_and_authors %}
+  {% if publish_date|trim or authors|trim or (node.show_teaser_text and content.field_teaser_text|render|trim) %}
+    <div class="publication-meta">
+      {% if publish_date|trim %}
+        <div class="publication-meta__publish-date">
+          <span class="publication-meta__label">{{ 'Published'|t }}:</span> {{ publish_date }}
+        </div>
+      {% endif %}
+      {% if node.show_teaser_text and content.field_teaser_text|render|trim %}
+        <div class="publication-meta__teaser-text">{{ content.field_teaser_text }}</div>
+      {% endif %}
+      {% if authors|trim %}
+        <div class="publication-meta__authors">{{ authors }}</div>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endset %}
+
+{# Journal info — publication name (italicised) and issue, on separate lines with labels #}
+{% set journal_name = node.field_journal_publication_name.0.value|default('')|trim %}
+{% set journal_issue = node.field_journal_publication_issue.0.value|default('')|trim %}
+{% set journal_info %}
+  {% if journal_name or journal_issue %}
+    <div class="publication-journal">
+      {% if journal_name %}
+        <div class="publication-journal__name">
+          <span class="publication-journal__label">{{ 'Publication'|t }}:</span> <em>{{ journal_name }}</em>
+        </div>
+      {% endif %}
+      {% if journal_issue %}
+        <div class="publication-journal__issue">
+          <span class="publication-journal__label">{{ 'Issue'|t }}:</span> {{ journal_issue }}
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endset %}
+
+{# Discipline taxonomy — comma-separated linked terms, label inline #}
+{% set discipline %}
+  {% if content.field_discipline|render|trim %}
+    <div class="publication-discipline">
+      <span class="publication-discipline__label">{{ 'Discipline'|t }}:</span>
+      <span class="publication-discipline__terms">
+        {% for item in content.field_discipline['#items'] %}
+          {% set term = item.entity %}
+          {% if term %}
+            <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': term.id}) }}">{{ term.label }}</a>{% if not loop.last %}, {% endif %}
+          {% endif %}
+        {% endfor %}
+      </span>
+    </div>
+  {% endif %}
+{% endset %}
+
 {% embed "@molecules/cards/reference-card/yds-reference-card.twig" with {
   reference_card__heading: heading,
   reference_card__url: url,
-  reference_card__overline: publish_date,
+  reference_card__subheading: date_and_authors,
+  reference_card__overline: node.show_discipline ? discipline : '',
   reference_card__image: node.show_thumbnail ? 'true' : 'false',
-  reference_card__snippet: content.field_teaser_text,
+  reference_card__snippet: node.show_publication ? journal_info : '',
   reference_card__image_aria: heading[0]['#context'].value,
   reference_card__overlay: node.pin_label,
   show_categories: node.show_category,
+  show_tags: node.show_tags,
 } %}
   {% block reference_card__categories %}
     {{ content.field_category }}
   {% endblock %}
 
+  {% block reference_card__tags %}
+    {{ content.field_tags }}
+  {% endblock %}
+
   {% block reference_card__image %}
+    {# Image fallback chain for Resource portrait-grid cards:
+        1. Editor-supplied teaser image (field_teaser_media)
+        2. The Resource's own file thumbnail (responsive_media_thumbnail) for
+           document and image bundles only — atomic_preprocess_node()
+           suppresses this for video bundles, where the auto-generated frame
+           is rarely useful as a card image
+        3. Site-wide fallback teaser image (portrait 5:8 crop)
+    #}
     {% if content.field_teaser_media[0] %}
       {{ content.field_teaser_media }}
-
     {% elseif responsive_media_thumbnail %}
       {{ responsive_media_thumbnail }}
-
     {% elseif getCoreSetting('image_fallback.teaser') %}
       {{ drupal_entity('media', getCoreSetting('image_fallback.teaser'), 'card_grid_portrait_5_8') }}
     {% endif %}


### PR DESCRIPTION
## [1221: RC: Resource View Portrait Grid missing field display options](https://github.com/yalesites-org/YaleSites-Internal/issues/1221)

### Description of work
- Updated `node--resource--portrait-grid.html.twig` to match the full conditional rendering logic from the card template, enabling show_tags, show_teaser_text, show_discipline, and show_publication to control field visibility in portrait grid cards
- Preserved the portrait-specific `card_grid_portrait_5_8` image style for the site-wide fallback image
- Other work completed in: yalesites-org/yalesites-project#1261

### Functional testing steps:
- [ ] In Layout Builder, add or edit a Resource Views block set to Portrait Grid
- [ ] Toggle Show Tags, Show Teaser Text, Show Discipline, Show Publication Information on/off and verify each field appears/disappears in the rendered cards
- [ ] Confirm Card Grid and List Item view modes are unaffected

Closes yalesites-org/YaleSites-Internal#1221