### PR TITLE
1225: RC: Publication Resource Cleanup V2

### DIFF
--- a/templates/node/node--resource--card.html.twig
+++ b/templates/node/node--resource--card.html.twig
@@ -14,8 +14,11 @@
 {% set date_format = content.field_date_format.0 ? content.field_date_format.0['#markup'] : '' %}
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
+{% set show_publish_date = node.show_publish_date is not defined or node.show_publish_date %}
+{% set show_authors = node.show_authors is not defined or node.show_authors %}
+
 {% set publish_date %}
-  {% if date_format %}
+  {% if show_publish_date and date_format %}
     {% include "@atoms/date-time/yds-date-time.twig" with {
       date_time__start: date_formatted,
       date_time__format: date_format,
@@ -23,10 +26,8 @@
   {% endif %}
 {% endset %}
 
-{# Authors — comma-separated. Affiliated authors link to their profile node;
-   non-affiliated authors (no profile, url is NULL) render as plain text. #}
 {% set authors %}
-  {% if resource_authors|length %}
+  {% if show_authors and resource_authors|length %}
     <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
     {% for author in resource_authors %}
       {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
@@ -34,11 +35,6 @@
   {% endif %}
 {% endset %}
 
-{# Combine published date, optional teaser text, and authors into one block.
-   Wrapping in a single outer div prevents the molecule's flex-child pipe separator
-   (`.reference-card__subheading > *:not(:first-child)::before { content: '|' }`) from
-   appearing between them. Tags render via the reference_card__tags block below
-   (matches post / event / page / profile cards). #}
 {% set date_and_authors %}
   {% if publish_date|trim or authors|trim or (node.show_teaser_text and content.field_teaser_text|render|trim) %}
     <div class="publication-meta">
@@ -57,18 +53,19 @@
   {% endif %}
 {% endset %}
 
-{# Journal info — publication name (italicised) and issue, on separate lines with labels #}
+{% set show_journal_name = node.show_journal_name is not defined or node.show_journal_name %}
+{% set show_journal_issue = node.show_journal_issue is not defined or node.show_journal_issue %}
 {% set journal_name = node.field_journal_publication_name.0.value|default('')|trim %}
 {% set journal_issue = node.field_journal_publication_issue.0.value|default('')|trim %}
 {% set journal_info %}
-  {% if journal_name or journal_issue %}
+  {% if (show_journal_name and journal_name) or (show_journal_issue and journal_issue) %}
     <div class="publication-journal">
-      {% if journal_name %}
+      {% if show_journal_name and journal_name %}
         <div class="publication-journal__name">
           <span class="publication-journal__label">{{ 'Publication'|t }}:</span> <em>{{ journal_name }}</em>
         </div>
       {% endif %}
-      {% if journal_issue %}
+      {% if show_journal_issue and journal_issue %}
         <div class="publication-journal__issue">
           <span class="publication-journal__label">{{ 'Issue'|t }}:</span> {{ journal_issue }}
         </div>
@@ -100,7 +97,7 @@
   reference_card__subheading: date_and_authors,
   reference_card__overline: node.show_discipline ? discipline : '',
   reference_card__image: node.show_thumbnail ? 'true' : 'false',
-  reference_card__snippet: node.show_publication ? journal_info : '',
+  reference_card__snippet: (show_journal_name or show_journal_issue) ? journal_info : '',
   reference_card__image_aria: heading[0]['#context'].value,
   reference_card__overlay: node.pin_label,
   show_categories: node.show_category,

--- a/templates/node/node--resource--card.html.twig
+++ b/templates/node/node--resource--card.html.twig
@@ -16,38 +16,32 @@
 
 {% set show_publish_date = node.show_publish_date is not defined or node.show_publish_date %}
 {% set show_authors = node.show_authors is not defined or node.show_authors %}
-
-{% set publish_date %}
-  {% if show_publish_date and date_format %}
-    {% include "@atoms/date-time/yds-date-time.twig" with {
-      date_time__start: date_formatted,
-      date_time__format: date_format,
-    } %}
-  {% endif %}
-{% endset %}
-
-{% set authors %}
-  {% if show_authors and resource_authors|length %}
-    <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
-    {% for author in resource_authors %}
-      {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
-    {% endfor %}
-  {% endif %}
-{% endset %}
+{% set has_publish_date = show_publish_date and date_format %}
+{% set has_authors = show_authors and resource_authors|length %}
+{% set has_teaser_text = node.show_teaser_text and content.field_teaser_text|render|trim %}
 
 {% set date_and_authors %}
-  {% if publish_date|trim or authors|trim or (node.show_teaser_text and content.field_teaser_text|render|trim) %}
+  {% if has_publish_date or has_authors or has_teaser_text %}
     <div class="publication-meta">
-      {% if publish_date|trim %}
+      {% if has_publish_date %}
         <div class="publication-meta__publish-date">
-          <span class="publication-meta__label">{{ 'Published'|t }}:</span> {{ publish_date }}
+          <span class="publication-meta__label">{{ 'Published'|t }}:</span>
+          {% include "@atoms/date-time/yds-date-time.twig" with {
+            date_time__start: date_formatted,
+            date_time__format: date_format,
+          } %}
         </div>
       {% endif %}
-      {% if node.show_teaser_text and content.field_teaser_text|render|trim %}
+      {% if has_teaser_text %}
         <div class="publication-meta__teaser-text">{{ content.field_teaser_text }}</div>
       {% endif %}
-      {% if authors|trim %}
-        <div class="publication-meta__authors">{{ authors }}</div>
+      {% if has_authors %}
+        <div class="publication-meta__authors">
+          <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
+          {% for author in resource_authors %}
+            {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        </div>
       {% endif %}
     </div>
   {% endif %}

--- a/templates/node/node--resource--condensed.html.twig
+++ b/templates/node/node--resource--condensed.html.twig
@@ -15,33 +15,27 @@
 
 {% set show_publish_date = node.show_publish_date is not defined or node.show_publish_date %}
 {% set show_authors = node.show_authors is not defined or node.show_authors %}
-
-{% set publish_date %}
-  {% if show_publish_date and date_format %}
-    {% include "@atoms/date-time/yds-date-time.twig" with {
-      date_time__start: date_formatted,
-      date_time__format: date_format,
-    } %}
-  {% endif %}
-{% endset %}
-
-{% set authors %}
-  {% if show_authors and resource_authors|length %}
-    <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
-    {% for author in resource_authors %}
-      {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
-    {% endfor %}
-  {% endif %}
-{% endset %}
+{% set has_publish_date = show_publish_date and date_format %}
+{% set has_authors = show_authors and resource_authors|length %}
 
 {% set date_and_authors %}
-  {% if publish_date|trim or authors|trim %}
+  {% if has_publish_date or has_authors %}
     <div class="publication-meta">
-      {% if publish_date|trim %}
-        <div class="publication-meta__publish-date">{{ publish_date }}</div>
+      {% if has_publish_date %}
+        <div class="publication-meta__publish-date">
+          {% include "@atoms/date-time/yds-date-time.twig" with {
+            date_time__start: date_formatted,
+            date_time__format: date_format,
+          } %}
+        </div>
       {% endif %}
-      {% if authors|trim %}
-        <div class="publication-meta__authors">{{ authors }}</div>
+      {% if has_authors %}
+        <div class="publication-meta__authors">
+          <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
+          {% for author in resource_authors %}
+            {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        </div>
       {% endif %}
     </div>
   {% endif %}

--- a/templates/node/node--resource--condensed.html.twig
+++ b/templates/node/node--resource--condensed.html.twig
@@ -13,8 +13,11 @@
 {% set date_format = content.field_date_format.0 ? content.field_date_format.0['#markup'] : '' %}
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
+{% set show_publish_date = node.show_publish_date is not defined or node.show_publish_date %}
+{% set show_authors = node.show_authors is not defined or node.show_authors %}
+
 {% set publish_date %}
-  {% if date_format %}
+  {% if show_publish_date and date_format %}
     {% include "@atoms/date-time/yds-date-time.twig" with {
       date_time__start: date_formatted,
       date_time__format: date_format,
@@ -22,10 +25,8 @@
   {% endif %}
 {% endset %}
 
-{# Authors — comma-separated. Affiliated authors link to their profile node;
-   non-affiliated authors (no profile, url is NULL) render as plain text. #}
 {% set authors %}
-  {% if resource_authors|length %}
+  {% if show_authors and resource_authors|length %}
     <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
     {% for author in resource_authors %}
       {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
@@ -33,10 +34,6 @@
   {% endif %}
 {% endset %}
 
-{# Combine published date and authors into one block so date sits directly above authors.
-   Wrapping both in a single outer div prevents the molecule's flex-child pipe separator
-   (`.reference-card__subheading > *:not(:first-child)::before { content: '|' }`) from
-   appearing between them. #}
 {% set date_and_authors %}
   {% if publish_date|trim or authors|trim %}
     <div class="publication-meta">

--- a/templates/node/node--resource--portrait-grid.html.twig
+++ b/templates/node/node--resource--portrait-grid.html.twig
@@ -14,8 +14,11 @@
 {% set date_format = content.field_date_format.0 ? content.field_date_format.0['#markup'] : '' %}
 {% set url = content.field_external_source[0]['#url']|render ? content.field_external_source[0]['#url']|render : url %}
 
+{% set show_publish_date = node.show_publish_date is not defined or node.show_publish_date %}
+{% set show_authors = node.show_authors is not defined or node.show_authors %}
+
 {% set publish_date %}
-  {% if date_format %}
+  {% if show_publish_date and date_format %}
     {% include "@atoms/date-time/yds-date-time.twig" with {
       date_time__start: date_formatted,
       date_time__format: date_format,
@@ -23,10 +26,8 @@
   {% endif %}
 {% endset %}
 
-{# Authors — comma-separated. Affiliated authors link to their profile node;
-   non-affiliated authors (no profile, url is NULL) render as plain text. #}
 {% set authors %}
-  {% if resource_authors|length %}
+  {% if show_authors and resource_authors|length %}
     <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
     {% for author in resource_authors %}
       {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
@@ -34,11 +35,6 @@
   {% endif %}
 {% endset %}
 
-{# Combine published date, optional teaser text, and authors into one block.
-   Wrapping in a single outer div prevents the molecule's flex-child pipe separator
-   (`.reference-card__subheading > *:not(:first-child)::before { content: '|' }`) from
-   appearing between them. Tags render via the reference_card__tags block below
-   (matches post / event / page / profile cards). #}
 {% set date_and_authors %}
   {% if publish_date|trim or authors|trim or (node.show_teaser_text and content.field_teaser_text|render|trim) %}
     <div class="publication-meta">
@@ -57,18 +53,19 @@
   {% endif %}
 {% endset %}
 
-{# Journal info — publication name (italicised) and issue, on separate lines with labels #}
+{% set show_journal_name = node.show_journal_name is not defined or node.show_journal_name %}
+{% set show_journal_issue = node.show_journal_issue is not defined or node.show_journal_issue %}
 {% set journal_name = node.field_journal_publication_name.0.value|default('')|trim %}
 {% set journal_issue = node.field_journal_publication_issue.0.value|default('')|trim %}
 {% set journal_info %}
-  {% if journal_name or journal_issue %}
+  {% if (show_journal_name and journal_name) or (show_journal_issue and journal_issue) %}
     <div class="publication-journal">
-      {% if journal_name %}
+      {% if show_journal_name and journal_name %}
         <div class="publication-journal__name">
           <span class="publication-journal__label">{{ 'Publication'|t }}:</span> <em>{{ journal_name }}</em>
         </div>
       {% endif %}
-      {% if journal_issue %}
+      {% if show_journal_issue and journal_issue %}
         <div class="publication-journal__issue">
           <span class="publication-journal__label">{{ 'Issue'|t }}:</span> {{ journal_issue }}
         </div>
@@ -100,7 +97,7 @@
   reference_card__subheading: date_and_authors,
   reference_card__overline: node.show_discipline ? discipline : '',
   reference_card__image: node.show_thumbnail ? 'true' : 'false',
-  reference_card__snippet: node.show_publication ? journal_info : '',
+  reference_card__snippet: (show_journal_name or show_journal_issue) ? journal_info : '',
   reference_card__image_aria: heading[0]['#context'].value,
   reference_card__overlay: node.pin_label,
   show_categories: node.show_category,

--- a/templates/node/node--resource--portrait-grid.html.twig
+++ b/templates/node/node--resource--portrait-grid.html.twig
@@ -16,38 +16,32 @@
 
 {% set show_publish_date = node.show_publish_date is not defined or node.show_publish_date %}
 {% set show_authors = node.show_authors is not defined or node.show_authors %}
-
-{% set publish_date %}
-  {% if show_publish_date and date_format %}
-    {% include "@atoms/date-time/yds-date-time.twig" with {
-      date_time__start: date_formatted,
-      date_time__format: date_format,
-    } %}
-  {% endif %}
-{% endset %}
-
-{% set authors %}
-  {% if show_authors and resource_authors|length %}
-    <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
-    {% for author in resource_authors %}
-      {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
-    {% endfor %}
-  {% endif %}
-{% endset %}
+{% set has_publish_date = show_publish_date and date_format %}
+{% set has_authors = show_authors and resource_authors|length %}
+{% set has_teaser_text = node.show_teaser_text and content.field_teaser_text|render|trim %}
 
 {% set date_and_authors %}
-  {% if publish_date|trim or authors|trim or (node.show_teaser_text and content.field_teaser_text|render|trim) %}
+  {% if has_publish_date or has_authors or has_teaser_text %}
     <div class="publication-meta">
-      {% if publish_date|trim %}
+      {% if has_publish_date %}
         <div class="publication-meta__publish-date">
-          <span class="publication-meta__label">{{ 'Published'|t }}:</span> {{ publish_date }}
+          <span class="publication-meta__label">{{ 'Published'|t }}:</span>
+          {% include "@atoms/date-time/yds-date-time.twig" with {
+            date_time__start: date_formatted,
+            date_time__format: date_format,
+          } %}
         </div>
       {% endif %}
-      {% if node.show_teaser_text and content.field_teaser_text|render|trim %}
+      {% if has_teaser_text %}
         <div class="publication-meta__teaser-text">{{ content.field_teaser_text }}</div>
       {% endif %}
-      {% if authors|trim %}
-        <div class="publication-meta__authors">{{ authors }}</div>
+      {% if has_authors %}
+        <div class="publication-meta__authors">
+          <span class="publication-meta__label">{{ resource_authors|length == 1 ? 'Author'|t : 'Authors'|t }}:</span>
+          {% for author in resource_authors %}
+            {% if author.url %}<a href="{{ author.url }}">{{ author.label }}</a>{% else %}{{ author.label }}{% endif %}{% if not loop.last %}, {% endif %}
+          {% endfor %}
+        </div>
       {% endif %}
     </div>
   {% endif %}


### PR DESCRIPTION
## [1225: RC: Publication Resource Cleanup V2](https://github.com/yalesites-org/YaleSites-Internal/issues/1225)

### Description of work
- Replace single `node.show_publication` toggle with individual field toggles (`show_journal_name`, `show_journal_issue`, `show_authors`, `show_publish_date`) in card, portrait-grid, and condensed resource templates
- Use `is not defined` fallback so full-page Resource view still shows all fields unconditionally
- Other work completed in: yalesites-org/yalesites-project#1263, yalesites-org/component-library-twig#640

### Functional testing steps:
- [ ] Add a Resource View block and toggle each publication field checkbox independently
- [ ] Verify each field shows/hides correctly in the view output
- [ ] Verify the full-page Resource view still shows all publication fields

References yalesites-org/YaleSites-Internal#1225