### PR TITLE
1311: RC: Accordion WYSIWYG shows bullets/numbered lists misaligned when first added

### DIFF
--- a/css/ckeditor5.css
+++ b/css/ckeditor5.css
@@ -30,6 +30,18 @@ div[contenteditable="true"] #drupal-off-canvas [data-drupal-ck-style-fence] .ck-
   color: black;
 }
 
+/*
+ * The broad reset above strips padding from every element inside a
+ * draggable-table editor (e.g. Accordion items), which also removes the
+ * indentation lists need. Without it, "outside" list markers render past the
+ * editing area: bullets sit far left and ordered-list numbers are clipped to
+ * just the trailing period. Restore list indentation so markers stay visible.
+ */
+.glb-table .ck-content ul,
+.glb-table .ck-content ol {
+  padding-inline-start: 40px;
+}
+
 .glb-table .ck-content tr:nth-child(2n) {
   background-color: var(--gin-bg-layer);
 }


### PR DESCRIPTION
## [1311: RC: Accordion WYSIWYG shows bullets/numbered lists misaligned when first added](https://github.com/yalesites-org/YaleSites-Internal/issues/1311)

### Description of work
- The broad reset `.glb-table .ck-content * { padding: 0 }` strips padding from every element inside a draggable-table editor (e.g. Accordion items). Because list markers use `list-style-position: outside`, the lost left padding pushed bullets past the editing area and clipped ordered-list numbers down to just the trailing period. The front end was unaffected because that reset only applies inside the editor.
- Add a more specific rule restoring `40px` inline-start padding to `ul` and `ol` inside `.glb-table .ck-content` so list markers stay visible while editing.
- The Text block is unaffected because it is not rendered in a draggable table.
- Other work completed in: yalesites-org/yalesites-project#1297

### Functional testing steps:
- [x] On the Drupal multidev (yalesites-org/yalesites-project#1297), create a new page and add an Accordion block via Layout Builder.
- [x] In the accordion item Text Content editor, add a bullet list and a numbered list.
- [x] Confirm bullets are indented and visible, and numbered items show the full number (not just a trailing `.`), on the initial add (before saving).
- [x] Confirm the Text block WYSIWYG lists still render correctly (no regression).

References yalesites-org/YaleSites-Internal#1311



Created with AI
