### PR TITLE
Bring in PRs held for after the 10/6 release

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -228,6 +228,7 @@ function atomic_preprocess_node(&$variables) {
     }
 
     // Create responsive_image render array using the thumbnail uri.
+    $alt = \Drupal::service('ys_layouts.media_alt_resolver')->resolve($media);
     $variables['responsive_media_thumbnail'] = [
       '#theme' => 'responsive_image',
       '#uri' => $file->getFileUri(),
@@ -236,7 +237,7 @@ function atomic_preprocess_node(&$variables) {
       '#width' => $thumbnail?->width,
       '#attributes' => [
         'loading' => 'lazy',
-        'alt' => $media->label(),
+        'alt' => $alt,
       ],
     ];
   }

--- a/templates/block/layout-builder/block--inline-block--cta-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--cta-banner.html.twig
@@ -1,5 +1,7 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
+{% set cta_banner__width = content.field_style_width.0['#markup']|default('site') %}
+
 {% block content %}
   {% embed "@molecules/banner/action/yds-action-banner.twig" with {
     banner__heading: content.field_heading,
@@ -13,7 +15,7 @@
     banner__content__layout: content.field_style_position.0['#markup'],
     banner__button__alignment: content.field_button_alignment.0['#markup'],
     banner__button__style__consistency: content.field_button_style_consistency.0['#markup'],
-    banner__width: 'site',
+    banner__width: cta_banner__width,
     banner__overlay_background_image: content.field_overlay_background_image.0['#media'].field_media_image.entity.fileuri|file_url,
   } %}
     {% block banner__image %}

--- a/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
+++ b/templates/block/layout-builder/block--inline-block--grand-hero.html.twig
@@ -1,5 +1,7 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
+{% set grand_hero__width = content.field_style_width.0['#markup']|default('site') %}
+
 {% block content %}
 
   {% embed "@molecules/banner/grand-hero/yds-grand-hero.twig" with {
@@ -13,7 +15,7 @@
     grand_hero__content__background: content.field_style_color.0['#markup'],
     grand_hero__overlay_variation: content.field_style_position.0['#markup'],
     grand_hero__size: content.field_style_variation.0['#markup'],
-    grand_hero__width: 'site',
+    grand_hero__width: grand_hero__width,
     grand_hero__overlay_png: content.field_overlay_png,
     grand_hero__replace_heading: content.field_replace_heading_with_image.0['#markup'],
   } %}

--- a/templates/block/layout-builder/block--inline-block--image-banner.html.twig
+++ b/templates/block/layout-builder/block--inline-block--image-banner.html.twig
@@ -2,13 +2,14 @@
 
 {% set image_banner__video = paragraph.field_media.entity.field_media_video_file.entity.uri.value is not empty %}
 {% set image_banner__image_size = content.field_style_variation.0['#markup']|default('tall') %}
+{% set image_banner__width = content.field_style_width.0['#markup']|default('site') %}
 
 {% block content %}
   {% embed "@molecules/banner/image/yds-image-banner.twig" with {
     image_banner__content__background: content.field_style_color.0['#markup'],
     image_banner__overlay_variation: 'full',
     image_banner__size: content.field_style_variation.0['#markup'],
-    image_banner__width: 'site',
+    image_banner__width: image_banner__width,
   } %}
     {% block image_banner__video %}
       {% if paragraph.field_media.entity.field_media_video_file.entity.uri.value is not empty %}


### PR DESCRIPTION
## Bring in PRs held for after the 10/6 release

### Description of work
- Merges `after-10-6-release` into `develop`, bringing in the PR that was ready to merge but was held back until a prior release shipped:
  - yalesites-org/atomic#462 - #1157 :: Extend Banner Width Control to All Banner Blocks
- Other work completed in: yalesites-org/component-library-twig#651
- Other work completed in: yalesites-org/yalesites-project#1313

### Functional testing steps:
- [ ] Confirm all banner block variants (action, grand hero, image) still render correctly with the new width control after merging into develop
- [ ] Confirm no visual regressions on existing banners using default width settings