### PR TITLE
1349: RC: Embed block: missing title attribute on Bluesky, Instagram, and event map embeds

### DIFF
--- a/templates/ys_embed/embed_wrapper.html.twig
+++ b/templates/ys_embed/embed_wrapper.html.twig
@@ -14,6 +14,8 @@
         } %}
         {% endembed %}
     </div>
+{% elseif title|trim != '' %}
+    <div role="group" aria-label="{{ title }}">{{ embedSource }}</div>
 {% else %}
     {{ embedSource }}
 {% endif %}


### PR DESCRIPTION
## [1349: RC: Embed block: missing title attribute on Bluesky, Instagram, and event map embeds](https://github.com/yalesites-org/YaleSites-Internal/issues/1349)

### Description of work
- Wraps non-iframe embed output (Bluesky, Instagram, etc.) in an accessible `role="group"`/`aria-label` container when a title is available — these embeds render as blockquote/script markup and previously had no accessible name
- Other work completed in: yalesites-org/component-library-twig#652
- Other work completed in: yalesites-org/yalesites-project#1314

### Functional testing steps:
- [ ] Add a Bluesky embed with Title left blank; confirm rendered markup includes `<div role="group" aria-label="Bluesky post embed">`
- [ ] Add an Instagram embed with an explicit Title; confirm that title is used instead of the default
- [ ] Confirm Bluesky/Instagram embeds still render and hydrate correctly (their embed.js scripts still find their blockquote)

References yalesites-org/YaleSites-Internal#1349