### PR TITLE
Bump component library twig to v1.79.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,9 +2087,9 @@
       "inBundle": true
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.79.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.79.0/d2ce5cf9c3012fb8ffbfdb0fae9921c844d4afde",
-      "integrity": "sha512-BPNVHvyVye/aTZ5u2t5FplGue9jwW3IjPG0IYtQIWbIF9F8x/DMuq3Z6kt2/ZK1eA1gLAG0NWMSpE1ihW5rnxA==",
+      "version": "1.79.1",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.79.1/98a091c253efcc019390c72c1fc8c39616abb6db",
+      "integrity": "sha512-F8TaOBTVwcQohJFzTu2GJu9CmvodEjkJKC3dzy3ZH++LQ69brmloR8O9lXkGtxLCAyv3Nf6RbIc/m3RPK3H+ew==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {


### PR DESCRIPTION
Bumps the `@yalesites-org/component-library-twig` dependency in `package-lock.json` from v1.79.0 to v1.79.1 to pick up the latest RC release.

Component library release: https://github.com/yalesites-org/component-library-twig/releases/tag/v1.79.1