### PR TITLE
1353: Wave 0: Pilot (prove the SDC recipe, the Web Component wrapper recipe, and the testing pattern)

### DIFF
--- a/components/accordion/accordion.component.yml
+++ b/components/accordion/accordion.component.yml
@@ -1,0 +1,63 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Accordion
+status: stable
+group: Molecules
+description: >
+  An expand/collapse accordion with a theme "dial" and JavaScript behavior. Thin
+  SDC wrapper over @molecules/accordion/yds-accordion.twig; the real markup, SCSS
+  and JS stay in component-library-twig. The component JS is attached via
+  libraryOverrides (the atomic/accordion library), because include/embed bypass
+  the Render API's #attached.
+libraryOverrides:
+  dependencies:
+    - atomic/accordion
+props:
+  type: object
+  properties:
+    accordion__theme:
+      title: Theme (dial)
+      description: >
+        Component color theme. Enum is generated from
+        ys_themes.component_overrides.yml (accordion.field_style_color,
+        list_key formatter), so the Drupal allowed values and this schema cannot
+        drift.
+      type: string
+      enum:
+        - default
+        - one
+        - two
+        - three
+        - four
+        - five
+      default: default
+    accordion__alignment:
+      title: Alignment
+      description: >
+        Content alignment. Computed by the block template from the parent node
+        type (not a dial): left for standard pages, center for post/event.
+      type: string
+      enum:
+        - left
+        - center
+      default: left
+    accordion__width:
+      title: Width
+      description: >
+        Content width. Computed by the block template from the parent node type
+        (not a dial): site for standard pages, content for post/event.
+      type: string
+      enum:
+        - site
+        - content
+      default: content
+slots:
+  accordion__heading:
+    title: Group heading
+    required: false
+    description: Optional heading displayed above all accordion items.
+  accordion__content:
+    title: Accordion items
+    required: true
+    description: >
+      The accordion item(s). Populated from the field_accordion_items field in
+      the Layout Builder block template.

--- a/components/accordion/accordion.twig
+++ b/components/accordion/accordion.twig
@@ -1,0 +1,29 @@
+{#
+ # SDC thin wrapper for the Accordion molecule. See the callout shim and
+ # docs/sdc/recipe-convert-a-component-to-sdc.md for the slot-forwarding pattern.
+ #
+ # Two slots:
+ #  - accordion__heading: the CLT template consumes this as a *variable*
+ #    (heading text), so the captured slot is passed through as accordion__heading.
+ #  - accordion__content: injected into the CLT template's accordion__items block
+ #    (named distinctly to avoid a block-name collision).
+ #
+ # JS/CSS attach via libraryOverrides (atomic/accordion). `directory` is threaded
+ # so the nested icon atom resolves the SVG sprite path.
+ #}
+{% set accordion__heading_slot = block('accordion__heading') %}
+{% set accordion__content_slot = block('accordion__content') %}
+{% embed '@molecules/accordion/yds-accordion.twig' with {
+  accordion__heading: accordion__heading_slot,
+  accordion__alignment: accordion__alignment,
+  accordion__theme: accordion__theme,
+  accordion__width: accordion__width,
+  accordion__content_slot: accordion__content_slot,
+  directory: directory,
+} only %}
+  {% block accordion__items %}{{ accordion__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}
+  {% block accordion__heading %}{% endblock %}
+  {% block accordion__content %}{% endblock %}
+{% endif %}

--- a/components/callout/callout.component.yml
+++ b/components/callout/callout.component.yml
@@ -1,0 +1,56 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Callout
+status: stable
+group: Molecules
+description: >
+  A callout block (heading, text, optional link) with a theme "dial". Thin SDC
+  wrapper over @molecules/callout/yds-callout.twig; the real markup and SCSS stay
+  in component-library-twig.
+props:
+  type: object
+  properties:
+    callout__background_color:
+      title: Theme (dial)
+      description: >
+        Component color theme. Enum is generated from
+        ys_themes.component_overrides.yml (callout.field_style_color) so the
+        Drupal-side allowed values and this schema cannot drift. field_style_color
+        uses the list_key formatter, so the machine keys are the runtime values.
+      type: string
+      enum:
+        - one
+        - two
+        - three
+        - four
+        - five
+      default: one
+    callout__alignment:
+      title: Alignment
+      description: >
+        Horizontal alignment of the callout content. Enum from
+        ys_themes.component_overrides.yml (callout.field_style_alignment,
+        list_key formatter).
+      type: string
+      enum:
+        - left
+        - center
+      default: center
+    callout__overlay_background_image:
+      title: Overlay background image URL
+      description: >
+        URL of an optional background image overlay. NOTE: the Storybook props
+        file types this as a boolean toggle, but the block template passes a file
+        URL string at render time, so the real prop type is string. The type is
+        nullable because the block template passes NULL when no overlay image is
+        set, and SDC validates NULL against the declared type.
+      type:
+        - string
+        - 'null'
+slots:
+  callout__content:
+    title: Callout content
+    required: true
+    description: >
+      The rendered callout item(s). Populated from the field_callout field in the
+      Layout Builder block template. Named callout__content (not callout__items)
+      to avoid colliding with the CLT template's internal callout__items block.

--- a/components/callout/callout.twig
+++ b/components/callout/callout.twig
@@ -1,0 +1,33 @@
+{#
+ # SDC thin wrapper for the Callout molecule.
+ #
+ # The canonical template + SCSS live in the component library
+ # (@molecules/callout/yds-callout.twig). This shim maps SDC props onto the
+ # template's variables and forwards the callout__content slot into the
+ # template's callout__items block.
+ #
+ # Slot forwarding pattern (see docs/sdc/recipe-convert-a-component-to-sdc.md):
+ #  - The slot is named callout__content, distinct from the CLT template's own
+ #    callout__items block, to avoid a Twig block-name collision.
+ #  - block('callout__content') captures the override so this works whether the
+ #    component is rendered via the SDC render element (#slots) or a Twig
+ #    {% embed %} block override.
+ #  - The captured value is passed through the (isolated, `only`) embed context
+ #    so it is in scope inside the override, and printed with |raw because it is
+ #    already-rendered, trusted Drupal output (block() returns a plain string).
+ #  - The receiver block is guarded by {% if false %} so it is registered at
+ #    compile time (for block() to find) but does not also render inline.
+ #  - `directory` is threaded so nested atoms (CTA/icon) resolve asset paths;
+ #    SDC does not inject `directory`.
+ #}
+{% set callout__content_slot = block('callout__content') %}
+{% embed '@molecules/callout/yds-callout.twig' with {
+  callout__background_color: callout__background_color,
+  callout__alignment: callout__alignment,
+  callout__overlay_background_image: callout__overlay_background_image,
+  callout__content_slot: callout__content_slot,
+  directory: directory,
+} only %}
+  {% block callout__items %}{{ callout__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block callout__content %}{% endblock %}{% endif %}

--- a/components/divider/divider.component.yml
+++ b/components/divider/divider.component.yml
@@ -1,0 +1,35 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Divider
+status: stable
+group: Atoms
+description: >
+  A horizontal rule / section divider. Thin SDC wrapper over the component
+  library's @atoms/divider/yds-divider.twig template; the real markup and SCSS
+  stay in component-library-twig.
+props:
+  type: object
+  properties:
+    divider__width:
+      title: Width
+      description: >
+        Width of the divider as a percentage of its container. Enum values are
+        the field_style_width labels (list_default formatter), which is what the
+        block template passes at render time.
+      type: string
+      enum:
+        - '100'
+        - '75'
+        - '50'
+        - '25'
+      default: '100'
+    divider__position:
+      title: Position
+      description: >
+        Horizontal alignment of the divider. Enum values are the
+        field_style_position labels (list_default formatter, capitalized); the
+        underlying template lowercases them before use.
+      type: string
+      enum:
+        - Left
+        - Center
+      default: Center

--- a/components/divider/divider.twig
+++ b/components/divider/divider.twig
@@ -1,0 +1,12 @@
+{#
+ # SDC thin wrapper for the Divider atom.
+ #
+ # The canonical template and SCSS live in the component library
+ # (@atoms/divider/yds-divider.twig). This shim only maps SDC props onto the
+ # template's variables. `with_context = false` keeps the include isolated to
+ # the props declared in divider.component.yml.
+ #}
+{{ include('@atoms/divider/yds-divider.twig', {
+  divider__width: divider__width,
+  divider__position: divider__position,
+}, with_context = false) }}

--- a/templates/block/layout-builder/block--inline-block--accordion.html.twig
+++ b/templates/block/layout-builder/block--inline-block--accordion.html.twig
@@ -2,8 +2,8 @@
 
 {% block content %}
 
-  {{ attach_library('atomic/accordion') }}
-
+  {# accordion__alignment and accordion__width are derived from the parent node
+     type, not a dial. #}
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set accordion__width = "content" %}
     {% set accordion__alignment = "center" %}
@@ -12,14 +12,16 @@
     {% set accordion__alignment = "left" %}
   {% endif %}
 
-  {% embed "@molecules/accordion/yds-accordion.twig" with {
-    accordion__heading: content.field_heading.0,
+  {# JS/CSS attach via the SDC's libraryOverrides (atomic/accordion); no manual
+     attach_library() needed. No `only`: the slot block overrides reference
+     `content`, and `directory` must flow into the SDC for the nested icon. #}
+  {% embed 'atomic:accordion' with {
     accordion__alignment: accordion__alignment,
-    accordion__theme: content.field_style_color.0['#markup'],
+    accordion__width: accordion__width,
+    accordion__theme: content.field_style_color.0['#markup']|default('default'),
   } %}
-    {% block accordion__items %}
-      {{ content.field_accordion_items }}
-    {% endblock %}
+    {% block accordion__heading %}{{ content.field_heading.0 }}{% endblock %}
+    {% block accordion__content %}{{ content.field_accordion_items }}{% endblock %}
   {% endembed %}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--callout.html.twig
+++ b/templates/block/layout-builder/block--inline-block--callout.html.twig
@@ -1,12 +1,16 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
-  {% embed "@molecules/callout/yds-callout.twig" with {
-      callout__background_color: content.field_style_color.0['#markup'],
-      callout__alignment: content.field_style_alignment.0['#markup'],
+  {# No `only`: the slot block override references `content`, and `directory`
+     must flow into the SDC so nested atoms resolve asset paths. Dial values are
+     defaulted here (adapter layer) because older blocks can store NULL and the
+     SDC schema enums are strict. #}
+  {% embed 'atomic:callout' with {
+      callout__background_color: content.field_style_color.0['#markup']|default('one'),
+      callout__alignment: content.field_style_alignment.0['#markup']|default('center'),
       callout__overlay_background_image: content.field_overlay_background_image.0['#media'].field_media_image.entity.fileuri|file_url,
   } %}
-    {% block callout__items %}
+    {% block callout__content %}
       {{ content.field_callout }}
     {% endblock %}
   {% endembed %}

--- a/templates/block/layout-builder/block--inline-block--divider.html.twig
+++ b/templates/block/layout-builder/block--inline-block--divider.html.twig
@@ -2,9 +2,13 @@
 
 {% block content %}
 
-  {% include "@atoms/divider/yds-divider.twig" with {
-    divider__position: content.field_style_position.0['#markup'],
-    divider__width: content.field_style_width.0['#markup'],
-  } %}
+  {# Default dial values here (the adapter layer): older blocks can store NULL,
+     and the SDC schema enums are strict. 'Center' matches the pre-SDC behavior
+     for a NULL position (the CLT template lowercased its own 'center' default)
+     and aligns with the schema default. #}
+  {{ include('atomic:divider', {
+    divider__position: content.field_style_position.0['#markup']|default('Center'),
+    divider__width: content.field_style_width.0['#markup']|default('100'),
+  }, with_context = false) }}
 
 {% endblock %}

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\Tests\atomic\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use JsonSchema\Validator;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Validates SDC component prop schemas against sample data.
+ *
+ * This is the lightweight, mechanical schema-validation pattern every wave of
+ * the SDC migration (epic #1351) reuses: valid data passes, invalid data (wrong
+ * enum / missing required) fails predictably. It uses justinrainbow/json-schema
+ * (available via drupal/core-dev) directly against the props schema authored in
+ * each *.component.yml, so it needs no Drupal bootstrap and runs fast in CI.
+ *
+ * Render-level enforcement (that SDC actually applies these schemas when
+ * assertions are on) is covered by the Kernel test.
+ *
+ * @group yalesites
+ * @group sdc
+ */
+class SdcSchemaValidationTest extends UnitTestCase {
+
+  /**
+   * Loads the props schema from a component's *.component.yml.
+   */
+  private function propsSchema(string $name): object {
+    $file = __DIR__ . "/../../../components/$name/$name.component.yml";
+    $this->assertFileExists($file, "component.yml for $name should exist");
+    $meta = Yaml::parseFile($file);
+    // Convert the parsed props array to the stdClass shape json-schema expects.
+    return json_decode(json_encode($meta['props']));
+  }
+
+  /**
+   * Validates $data against a component's props schema; returns error array.
+   */
+  private function validate(string $name, array $data): array {
+    $validator = new Validator();
+    $subject = json_decode(json_encode($data));
+    $validator->validate($subject, $this->propsSchema($name));
+    return $validator->getErrors();
+  }
+
+  /**
+   * Divider: the cheap case. Valid width/position pass.
+   */
+  public function testDividerValidData(): void {
+    $this->assertSame([], $this->validate('divider', [
+      'divider__width' => '50',
+      'divider__position' => 'Left',
+    ]));
+  }
+
+  /**
+   * Divider: an out-of-enum width fails predictably.
+   */
+  public function testDividerInvalidWidthFails(): void {
+    $this->assertNotEmpty($this->validate('divider', [
+      'divider__width' => '999',
+    ]));
+  }
+
+  /**
+   * Callout: a valid dial value passes.
+   */
+  public function testCalloutValidDial(): void {
+    $this->assertSame([], $this->validate('callout', [
+      'callout__background_color' => 'three',
+      'callout__alignment' => 'left',
+    ]));
+  }
+
+  /**
+   * Callout: an invalid dial value fails.
+   *
+   * This is the no-drift enforcement, proven at the schema level (render-level
+   * enforcement is covered separately).
+   */
+  public function testCalloutInvalidDialFails(): void {
+    $this->assertNotEmpty($this->validate('callout', [
+      'callout__background_color' => 'not-a-real-theme',
+      'callout__alignment' => 'center',
+    ]));
+  }
+
+  /**
+   * Accordion: a valid dial value passes.
+   */
+  public function testAccordionValidDial(): void {
+    $this->assertSame([], $this->validate('accordion', [
+      'accordion__theme' => 'default',
+      'accordion__alignment' => 'left',
+      'accordion__width' => 'content',
+    ]));
+  }
+
+}


### PR DESCRIPTION
## [1353: Wave 0: Pilot](https://github.com/yalesites-org/YaleSites-Internal/issues/1353)

Wave 0 pilot of the full SDC migration (epic yalesites-org/YaleSites-Internal#1351). Establishes the thin-wrapper SDC architecture in the `atomic` theme, proven on three components.

### What's here (atomic)
- Three thin-wrapper Single Directory Components in `atomic/components/`: **divider** (props-only), **callout** (props + dial enum + slot), **accordion** (props + slots + JS via `libraryOverrides`). Each is a `*.component.yml` schema + a `*.twig` shim that delegates to the canonical `@atoms`/`@molecules` template (which stays in the component library).
- The three matching Layout Builder block templates repointed at the SDCs.
- A PHP schema-validation Unit test (`justinrainbow/json-schema`) under `atomic/tests/`.

### Verified
All three render **byte-identical to the pre-SDC baseline** on real Lando pages (normalized before/after diff), and the accordion JS attaches via `libraryOverrides`. Code review caught and fixed a real divider-default regression (NULL position center→left).

### Companion work
Other work completed in: yalesites-org/component-library-twig (recipe docs, Vitest tests, Web Component wrappers) and yalesites-org/yalesites-project (codegen + schema-test script) — same branch name for the multidev build.

See the recipe: `component-library-twig/docs/sdc/recipe-convert-a-component-to-sdc.md`.

References yalesites-org/YaleSites-Internal#1353