### PR TITLE
1355: Wave 2: Static presentational molecules (no JS)

### DIFF
--- a/components/accordion/accordion.component.yml
+++ b/components/accordion/accordion.component.yml
@@ -1,0 +1,63 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Accordion
+status: stable
+group: Molecules
+description: >
+  An expand/collapse accordion with a theme "dial" and JavaScript behavior. Thin
+  SDC wrapper over @molecules/accordion/yds-accordion.twig; the real markup, SCSS
+  and JS stay in component-library-twig. The component JS is attached via
+  libraryOverrides (the atomic/accordion library), because include/embed bypass
+  the Render API's #attached.
+libraryOverrides:
+  dependencies:
+    - atomic/accordion
+props:
+  type: object
+  properties:
+    accordion__theme:
+      title: Theme (dial)
+      description: >
+        Component color theme. Enum is generated from
+        ys_themes.component_overrides.yml (accordion.field_style_color,
+        list_key formatter), so the Drupal allowed values and this schema cannot
+        drift.
+      type: string
+      enum:
+        - default
+        - one
+        - two
+        - three
+        - four
+        - five
+      default: default
+    accordion__alignment:
+      title: Alignment
+      description: >
+        Content alignment. Computed by the block template from the parent node
+        type (not a dial): left for standard pages, center for post/event.
+      type: string
+      enum:
+        - left
+        - center
+      default: left
+    accordion__width:
+      title: Width
+      description: >
+        Content width. Computed by the block template from the parent node type
+        (not a dial): site for standard pages, content for post/event.
+      type: string
+      enum:
+        - site
+        - content
+      default: content
+slots:
+  accordion__heading:
+    title: Group heading
+    required: false
+    description: Optional heading displayed above all accordion items.
+  accordion__content:
+    title: Accordion items
+    required: true
+    description: >
+      The accordion item(s). Populated from the field_accordion_items field in
+      the Layout Builder block template.

--- a/components/accordion/accordion.twig
+++ b/components/accordion/accordion.twig
@@ -1,0 +1,29 @@
+{#
+ # SDC thin wrapper for the Accordion molecule. See the callout shim and
+ # docs/sdc/recipe-convert-a-component-to-sdc.md for the slot-forwarding pattern.
+ #
+ # Two slots:
+ #  - accordion__heading: the CLT template consumes this as a *variable*
+ #    (heading text), so the captured slot is passed through as accordion__heading.
+ #  - accordion__content: injected into the CLT template's accordion__items block
+ #    (named distinctly to avoid a block-name collision).
+ #
+ # JS/CSS attach via libraryOverrides (atomic/accordion). `directory` is threaded
+ # so the nested icon atom resolves the SVG sprite path.
+ #}
+{% set accordion__heading_slot = block('accordion__heading') %}
+{% set accordion__content_slot = block('accordion__content') %}
+{% embed '@molecules/accordion/yds-accordion.twig' with {
+  accordion__heading: accordion__heading_slot,
+  accordion__alignment: accordion__alignment,
+  accordion__theme: accordion__theme,
+  accordion__width: accordion__width,
+  accordion__content_slot: accordion__content_slot,
+  directory: directory,
+} only %}
+  {% block accordion__items %}{{ accordion__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}
+  {% block accordion__heading %}{% endblock %}
+  {% block accordion__content %}{% endblock %}
+{% endif %}

--- a/components/basic-meta/basic-meta.component.yml
+++ b/components/basic-meta/basic-meta.component.yml
@@ -1,0 +1,15 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Basic Meta
+status: stable
+group: Molecules
+description: >
+  Simple meta text (a thin wrapper over the text atom). Thin SDC wrapper over
+  @molecules/meta/basic-meta/yds-basic-meta.twig.
+props:
+  type: object
+  properties: {}
+slots:
+  basic_meta_content:
+    title: Meta content
+    required: true
+    description: The meta text/markup.

--- a/components/basic-meta/basic-meta.twig
+++ b/components/basic-meta/basic-meta.twig
@@ -1,0 +1,9 @@
+{#
+ # SDC thin wrapper for Basic Meta. The captured slot is passed as the
+ # basic_meta variable (the template forwards it to the text atom's content).
+ #}
+{% set basic_meta_content = block('basic_meta_content') %}
+{{ include('@molecules/meta/basic-meta/yds-basic-meta.twig', {
+  basic_meta: basic_meta_content|trim,
+}, with_context = false) }}
+{% if false %}{% block basic_meta_content %}{% endblock %}{% endif %}

--- a/components/callout/callout.component.yml
+++ b/components/callout/callout.component.yml
@@ -1,0 +1,56 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Callout
+status: stable
+group: Molecules
+description: >
+  A callout block (heading, text, optional link) with a theme "dial". Thin SDC
+  wrapper over @molecules/callout/yds-callout.twig; the real markup and SCSS stay
+  in component-library-twig.
+props:
+  type: object
+  properties:
+    callout__background_color:
+      title: Theme (dial)
+      description: >
+        Component color theme. Enum is generated from
+        ys_themes.component_overrides.yml (callout.field_style_color) so the
+        Drupal-side allowed values and this schema cannot drift. field_style_color
+        uses the list_key formatter, so the machine keys are the runtime values.
+      type: string
+      enum:
+        - one
+        - two
+        - three
+        - four
+        - five
+      default: one
+    callout__alignment:
+      title: Alignment
+      description: >
+        Horizontal alignment of the callout content. Enum from
+        ys_themes.component_overrides.yml (callout.field_style_alignment,
+        list_key formatter).
+      type: string
+      enum:
+        - left
+        - center
+      default: center
+    callout__overlay_background_image:
+      title: Overlay background image URL
+      description: >
+        URL of an optional background image overlay. NOTE: the Storybook props
+        file types this as a boolean toggle, but the block template passes a file
+        URL string at render time, so the real prop type is string. The type is
+        nullable because the block template passes NULL when no overlay image is
+        set, and SDC validates NULL against the declared type.
+      type:
+        - string
+        - 'null'
+slots:
+  callout__content:
+    title: Callout content
+    required: true
+    description: >
+      The rendered callout item(s). Populated from the field_callout field in the
+      Layout Builder block template. Named callout__content (not callout__items)
+      to avoid colliding with the CLT template's internal callout__items block.

--- a/components/callout/callout.twig
+++ b/components/callout/callout.twig
@@ -1,0 +1,33 @@
+{#
+ # SDC thin wrapper for the Callout molecule.
+ #
+ # The canonical template + SCSS live in the component library
+ # (@molecules/callout/yds-callout.twig). This shim maps SDC props onto the
+ # template's variables and forwards the callout__content slot into the
+ # template's callout__items block.
+ #
+ # Slot forwarding pattern (see docs/sdc/recipe-convert-a-component-to-sdc.md):
+ #  - The slot is named callout__content, distinct from the CLT template's own
+ #    callout__items block, to avoid a Twig block-name collision.
+ #  - block('callout__content') captures the override so this works whether the
+ #    component is rendered via the SDC render element (#slots) or a Twig
+ #    {% embed %} block override.
+ #  - The captured value is passed through the (isolated, `only`) embed context
+ #    so it is in scope inside the override, and printed with |raw because it is
+ #    already-rendered, trusted Drupal output (block() returns a plain string).
+ #  - The receiver block is guarded by {% if false %} so it is registered at
+ #    compile time (for block() to find) but does not also render inline.
+ #  - `directory` is threaded so nested atoms (CTA/icon) resolve asset paths;
+ #    SDC does not inject `directory`.
+ #}
+{% set callout__content_slot = block('callout__content') %}
+{% embed '@molecules/callout/yds-callout.twig' with {
+  callout__background_color: callout__background_color,
+  callout__alignment: callout__alignment,
+  callout__overlay_background_image: callout__overlay_background_image,
+  callout__content_slot: callout__content_slot,
+  directory: directory,
+} only %}
+  {% block callout__items %}{{ callout__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block callout__content %}{% endblock %}{% endif %}

--- a/components/cta/cta.component.yml
+++ b/components/cta/cta.component.yml
@@ -1,0 +1,47 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: CTA
+status: stable
+group: Atoms
+description: >
+  A call-to-action button/link. Thin SDC wrapper over
+  @atoms/controls/cta/yds-cta.twig; the real template and SCSS stay in
+  component-library-twig. Strong Web Component candidate (Wave 10).
+props:
+  type: object
+  properties:
+    cta__href:
+      title: URL
+      description: The URL the CTA points to (rendered as a link when set).
+      type:
+        - string
+        - "null"
+    cta__hover_style:
+      title: Hover style
+      type: string
+      enum: [fade, rise, swipe]
+      default: fade
+    cta__radius:
+      title: Corner radius
+      type: string
+      enum: [none, soft, pill]
+      default: none
+    cta__style:
+      title: Fill style
+      type: string
+      enum: [filled, outline]
+      default: filled
+    cta__outline_weight:
+      title: Outline weight
+      type: string
+      enum: ["1", "2", "4"]
+      default: "2"
+    cta__control_type:
+      title: Control type
+      description: Whether the CTA renders as a link or a button.
+      type: string
+      default: link
+slots:
+  cta__content:
+    title: CTA content
+    required: true
+    description: The CTA label/content. Consumed as a variable by the template.

--- a/components/cta/cta.twig
+++ b/components/cta/cta.twig
@@ -1,0 +1,16 @@
+{#
+ # SDC thin wrapper for the CTA atom. cta__content is consumed as a variable by
+ # the template (passed to the base control), so the captured slot is passed
+ # through. See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set cta__content_slot = block('cta__content') %}
+{{ include('@atoms/controls/cta/yds-cta.twig', {
+  cta__href: cta__href,
+  cta__hover_style: cta__hover_style,
+  cta__radius: cta__radius,
+  cta__style: cta__style,
+  cta__outline_weight: cta__outline_weight,
+  cta__control_type: cta__control_type,
+  cta__content: cta__content_slot|trim,
+}, with_context = false) }}
+{% if false %}{% block cta__content %}{% endblock %}{% endif %}

--- a/components/date-time/date-time.component.yml
+++ b/components/date-time/date-time.component.yml
@@ -1,0 +1,53 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Date Time
+status: stable
+group: Atoms
+description: >
+  A formatted date/time range (<time> element). Thin SDC wrapper over
+  @atoms/date-time/yds-date-time.twig; the real formatting logic and SCSS stay
+  in component-library-twig.
+props:
+  type: object
+  required:
+    - date_time__start
+  properties:
+    date_time__start:
+      title: Start
+      description: Start date/time (a Unix timestamp or a date string Twig's date filter accepts).
+      type:
+        - string
+        - number
+    date_time__end:
+      title: End
+      description: Optional end date/time; defaults to the start when omitted.
+      type:
+        - string
+        - number
+        - "null"
+    date_time__all_day:
+      title: All day
+      type:
+        - boolean
+        - "null"
+    date_time__format:
+      title: Format
+      description: Named format configuration.
+      type: string
+      enum:
+        - time
+        - date
+        - date_and_time
+        - all_day
+        - day__full
+        - year_only
+        - month_year
+        - same_day_diff_time
+        - date_time_multiple_days
+        - localist_same_day
+      default: date_and_time
+    date_time__format_override:
+      title: Format override
+      description: Advanced — override the named format with a specific format key.
+      type:
+        - string
+        - "null"

--- a/components/date-time/date-time.twig
+++ b/components/date-time/date-time.twig
@@ -1,0 +1,11 @@
+{#
+ # SDC thin wrapper for the Date Time atom. Props-only (no slots); the date
+ # formatting logic stays in the component library template.
+ #}
+{{ include('@atoms/date-time/yds-date-time.twig', {
+  date_time__start: date_time__start,
+  date_time__end: date_time__end,
+  date_time__all_day: date_time__all_day,
+  date_time__format: date_time__format,
+  date_time__format_override: date_time__format_override,
+}, with_context = false) }}

--- a/components/divider/divider.component.yml
+++ b/components/divider/divider.component.yml
@@ -1,0 +1,35 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Divider
+status: stable
+group: Atoms
+description: >
+  A horizontal rule / section divider. Thin SDC wrapper over the component
+  library's @atoms/divider/yds-divider.twig template; the real markup and SCSS
+  stay in component-library-twig.
+props:
+  type: object
+  properties:
+    divider__width:
+      title: Width
+      description: >
+        Width of the divider as a percentage of its container. Enum values are
+        the field_style_width labels (list_default formatter), which is what the
+        block template passes at render time.
+      type: string
+      enum:
+        - '100'
+        - '75'
+        - '50'
+        - '25'
+      default: '100'
+    divider__position:
+      title: Position
+      description: >
+        Horizontal alignment of the divider. Enum values are the
+        field_style_position labels (list_default formatter, capitalized); the
+        underlying template lowercases them before use.
+      type: string
+      enum:
+        - Left
+        - Center
+      default: Center

--- a/components/divider/divider.twig
+++ b/components/divider/divider.twig
@@ -1,0 +1,12 @@
+{#
+ # SDC thin wrapper for the Divider atom.
+ #
+ # The canonical template and SCSS live in the component library
+ # (@atoms/divider/yds-divider.twig). This shim only maps SDC props onto the
+ # template's variables. `with_context = false` keeps the include isolated to
+ # the props declared in divider.component.yml.
+ #}
+{{ include('@atoms/divider/yds-divider.twig', {
+  divider__width: divider__width,
+  divider__position: divider__position,
+}, with_context = false) }}

--- a/components/heading/heading.component.yml
+++ b/components/heading/heading.component.yml
@@ -1,0 +1,34 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Heading
+status: stable
+group: Atoms
+description: >
+  A heading (h1-h6), optionally linked and/or prefixed with an icon. Thin SDC
+  wrapper over @atoms/typography/headings/yds-heading.twig; the real template
+  and SCSS stay in component-library-twig.
+props:
+  type: object
+  properties:
+    heading__level:
+      title: Level
+      description: The heading level, producing h1-h6.
+      type: string
+      enum: ["1", "2", "3", "4", "5", "6"]
+      default: "2"
+    heading__url:
+      title: Link URL
+      description: Optional URL; when set, the heading text is wrapped in a link.
+      type:
+        - string
+        - "null"
+    heading__prefix__icon:
+      title: Prefix icon name
+      description: Optional icon name rendered before the heading text.
+      type:
+        - string
+        - "null"
+slots:
+  heading:
+    title: Heading content
+    required: true
+    description: The heading text (or markup). Consumed as a variable by the template.

--- a/components/heading/heading.twig
+++ b/components/heading/heading.twig
@@ -1,0 +1,16 @@
+{#
+ # SDC thin wrapper for the Heading atom. The CLT template consumes `heading` as
+ # a variable (both printed directly and passed to the text-link atom), so the
+ # captured slot is passed through as `heading`. `directory` is threaded so the
+ # optional prefix icon resolves its sprite path.
+ # See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set heading_slot = block('heading') %}
+{{ include('@atoms/typography/headings/yds-heading.twig', {
+  heading__level: heading__level,
+  heading: heading_slot|trim,
+  heading__url: heading__url,
+  heading__prefix__icon: heading__prefix__icon,
+  directory: directory,
+}, with_context = false) }}
+{% if false %}{% block heading %}{% endblock %}{% endif %}

--- a/components/image/image.component.yml
+++ b/components/image/image.component.yml
@@ -1,0 +1,27 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Image
+status: stable
+group: Atoms
+description: >
+  An image, optionally wrapped in a <figure> with a caption. Thin SDC wrapper
+  over @atoms/images/image/yds-image.twig; the responsive-image markup is
+  provided as a slot (it is typically a Drupal responsive-image render array).
+props:
+  type: object
+  properties:
+    figure__caption:
+      title: Caption
+      description: >
+        Optional caption. When present the image is wrapped in a <figure>. Passed
+        as already-rendered markup (the template prints it with |raw for WYSIWYG).
+      type:
+        - string
+        - "null"
+slots:
+  image__content:
+    title: Image markup
+    required: true
+    description: >
+      The image markup (typically a Drupal responsive-image render array). Named
+      image__content (not image__image) to avoid a collision with the template's
+      own image__image block.

--- a/components/image/image.twig
+++ b/components/image/image.twig
@@ -1,0 +1,13 @@
+{#
+ # SDC thin wrapper for the Image atom. The image markup is injected into the
+ # template's image__image block; figure__caption is passed as a variable.
+ # See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set image__content = block('image__content') %}
+{% embed '@atoms/images/image/yds-image.twig' with {
+  figure__caption: figure__caption,
+  image__content: image__content,
+} only %}
+  {% block image__image %}{{ image__content|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block image__content %}{% endblock %}{% endif %}

--- a/components/inline-message/inline-message.component.yml
+++ b/components/inline-message/inline-message.component.yml
@@ -1,0 +1,48 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Inline Message
+status: stable
+group: Molecules
+description: >
+  An inline informational/marketing message with an icon, heading, body and
+  optional link. Thin SDC wrapper over
+  @molecules/inline-message/yds-inline-message.twig.
+props:
+  type: object
+  properties:
+    inline_message__theme:
+      title: Theme (dial)
+      description: >
+        Color theme. Enum from ys_themes.component_overrides.yml
+        (inline_message.field_style_color, list_key formatter).
+      type: string
+      enum: [one, two, three, four, five]
+      default: one
+    inline_message__type:
+      title: Type
+      type: string
+      enum: [general, marketing]
+      default: general
+    inline_message__heading_level:
+      title: Heading level
+      type:
+        - string
+        - "null"
+    inline_message__link__content:
+      title: Link text
+      type:
+        - string
+        - "null"
+    inline_message__link__url:
+      title: Link URL
+      type:
+        - string
+        - "null"
+slots:
+  inline_message__heading:
+    title: Heading
+    required: false
+    description: The message heading (plain text).
+  inline_message__content:
+    title: Content
+    required: false
+    description: The message body (rich text; rendered via the text atom).

--- a/components/inline-message/inline-message.twig
+++ b/components/inline-message/inline-message.twig
@@ -1,0 +1,22 @@
+{#
+ # SDC thin wrapper for the Inline Message molecule. heading and content are
+ # consumed as variables by the template (heading -> heading atom; content ->
+ # text atom, which prints it with |raw). directory is threaded for the icon.
+ # See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set inline_message__heading_slot = block('inline_message__heading') %}
+{% set inline_message__content_slot = block('inline_message__content') %}
+{{ include('@molecules/inline-message/yds-inline-message.twig', {
+  inline_message__type: inline_message__type,
+  inline_message__theme: inline_message__theme,
+  inline_message__heading_level: inline_message__heading_level,
+  inline_message__heading: inline_message__heading_slot|trim,
+  inline_message__content: inline_message__content_slot,
+  inline_message__link__content: inline_message__link__content,
+  inline_message__link__url: inline_message__link__url,
+  directory: directory,
+}, with_context = false) }}
+{% if false %}
+  {% block inline_message__heading %}{% endblock %}
+  {% block inline_message__content %}{% endblock %}
+{% endif %}

--- a/components/link-grid/link-grid.component.yml
+++ b/components/link-grid/link-grid.component.yml
@@ -1,0 +1,46 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Link Grid
+status: stable
+group: Molecules
+description: >
+  A grid of up to four link columns with an optional overall heading. Thin SDC
+  wrapper over @molecules/link-grid/yds-link-grid.twig.
+props:
+  type: object
+  properties:
+    link_grid__theme:
+      title: Theme (dial)
+      description: >
+        field_style_color (list_key), plus "inherit" when placed in a 50/50
+        two-column layout.
+      type: string
+      enum: [one, two, three, four, five, inherit]
+      default: one
+    link_grid__width:
+      title: Width
+      type:
+        - string
+        - "null"
+    link_grid__line_treatment:
+      title: Line treatment
+      type:
+        - string
+        - "null"
+slots:
+  link_grid__heading:
+    title: Heading
+    required: false
+    description: Optional overall heading.
+  link_grid__col_one:
+    title: Column one links
+    required: false
+    description: Links for column one (named __col_one to avoid the template's link block).
+  link_grid__col_two:
+    title: Column two links
+    required: false
+  link_grid__col_three:
+    title: Column three links
+    required: false
+  link_grid__col_four:
+    title: Column four links
+    required: false

--- a/components/link-grid/link-grid.twig
+++ b/components/link-grid/link-grid.twig
@@ -1,0 +1,36 @@
+{#
+ # SDC thin wrapper for the Link Grid molecule. Four optional link columns: each
+ # captured slot both gates the template's {% if link_grid__links_N %} (via a
+ # derived truthiness value) and provides the column content (injected into the
+ # matching CLT block). SDC slots are named __col_* to avoid colliding with the
+ # template's own link_grid__links_* blocks.
+ # See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set link_grid__heading_slot %}{{ block('link_grid__heading')|raw }}{% endset %}
+{% set c1 %}{{ block('link_grid__col_one')|raw }}{% endset %}
+{% set c2 %}{{ block('link_grid__col_two')|raw }}{% endset %}
+{% set c3 %}{{ block('link_grid__col_three')|raw }}{% endset %}
+{% set c4 %}{{ block('link_grid__col_four')|raw }}{% endset %}
+{% embed '@molecules/link-grid/yds-link-grid.twig' with {
+  link_grid__theme: link_grid__theme,
+  link_grid__width: link_grid__width,
+  link_grid__line_treatment: link_grid__line_treatment,
+  link_grid__heading: link_grid__heading_slot|trim is empty ? '' : link_grid__heading_slot,
+  link_grid__links_one: c1|trim is empty ? '' : true,
+  link_grid__links_two: c2|trim is empty ? '' : true,
+  link_grid__links_three: c3|trim is empty ? '' : true,
+  link_grid__links_four: c4|trim is empty ? '' : true,
+  c1: c1, c2: c2, c3: c3, c4: c4,
+} only %}
+  {% block link_grid__links_one %}{{ c1|raw }}{% endblock %}
+  {% block link_grid__links_two %}{{ c2|raw }}{% endblock %}
+  {% block link_grid__links_three %}{{ c3|raw }}{% endblock %}
+  {% block link_grid__links_four %}{{ c4|raw }}{% endblock %}
+{% endembed %}
+{% if false %}
+  {% block link_grid__heading %}{% endblock %}
+  {% block link_grid__col_one %}{% endblock %}
+  {% block link_grid__col_two %}{% endblock %}
+  {% block link_grid__col_three %}{% endblock %}
+  {% block link_grid__col_four %}{% endblock %}
+{% endif %}

--- a/components/link-skip/link-skip.component.yml
+++ b/components/link-skip/link-skip.component.yml
@@ -1,0 +1,28 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Skip Link
+status: stable
+group: Atoms
+description: >
+  A skip-to-content link (accessibility). Thin SDC wrapper over
+  @molecules/link-skip/yds-link-skip.twig.
+props:
+  type: object
+  properties:
+    link_skip__url:
+      title: Target URL
+      description: The in-page target the skip link jumps to (e.g. #main-content).
+      type:
+        - string
+        - "null"
+    link_skip__extra_class:
+      title: Extra class
+      type:
+        - string
+        - "null"
+slots:
+  link_skip__content_slot:
+    title: Link content
+    required: true
+    description: >
+      The link text. Named link_skip__content_slot (not link_skip__content) to
+      avoid a collision with the template's own link_skip__content block.

--- a/components/link-skip/link-skip.twig
+++ b/components/link-skip/link-skip.twig
@@ -1,0 +1,13 @@
+{#
+ # SDC thin wrapper for the Skip Link. The slot is injected into the template's
+ # link_skip__content block. See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set link_skip__content_slot = block('link_skip__content_slot') %}
+{% embed '@molecules/link-skip/yds-link-skip.twig' with {
+  link_skip__url: link_skip__url,
+  link_skip__extra_class: link_skip__extra_class,
+  link_skip__content_slot: link_skip__content_slot,
+} only %}
+  {% block link_skip__content %}{{ link_skip__content_slot|trim|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block link_skip__content_slot %}{% endblock %}{% endif %}

--- a/components/lists/lists.component.yml
+++ b/components/lists/lists.component.yml
@@ -1,0 +1,28 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Lists
+status: stable
+group: Atoms
+description: >
+  An ordered or unordered list. Thin SDC wrapper over
+  @atoms/lists/yds-list.twig; the real template and SCSS stay in
+  component-library-twig. Seeded by scripts/sdc/generate-sdc.js, then refined:
+  the codegen's story-only list__items array-prop was dropped in favor of the
+  list__content slot.
+props:
+  type: object
+  properties:
+    list__type:
+      title: List type
+      description: HTML list element type (ul for unordered, ol for ordered).
+      type: string
+      enum:
+        - ul
+        - ol
+      default: ul
+slots:
+  list__content_slot:
+    title: List content
+    required: true
+    description: >
+      The list items. Named list__content_slot (not list__content) to avoid a
+      collision with the template's own list__content block.

--- a/components/lists/lists.twig
+++ b/components/lists/lists.twig
@@ -1,0 +1,12 @@
+{#
+ # SDC thin wrapper for the Lists atom. The slot is injected into the template's
+ # list__content block. See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set list__content_slot = block('list__content_slot') %}
+{% embed '@atoms/lists/yds-list.twig' with {
+  list__type: list__type,
+  list__content_slot: list__content_slot,
+} only %}
+  {% block list__content %}{{ list__content_slot|trim|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block list__content_slot %}{% endblock %}{% endif %}

--- a/components/pull-quote/pull-quote.component.yml
+++ b/components/pull-quote/pull-quote.component.yml
@@ -1,0 +1,39 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Pull Quote
+status: stable
+group: Molecules
+description: >
+  A pull quote with optional attribution. Thin SDC wrapper over
+  @molecules/pull-quote/yds-pull-quote.twig.
+props:
+  type: object
+  properties:
+    pull_quote__style:
+      title: Style (dial)
+      description: >
+        Enum from ys_themes.component_overrides.yml (pull_quote.field_style_variation,
+        list_key formatter).
+      type: string
+      enum: [bar-left, bar-right, quote-left]
+      default: bar-left
+    pull_quote__width:
+      title: Width
+      description: Content width; computed by the block template from the parent node type.
+      type:
+        - string
+        - "null"
+    pull_quote__alignment:
+      title: Alignment
+      description: Content alignment; computed by the block template from the parent node type.
+      type:
+        - string
+        - "null"
+slots:
+  pull_quote__quote:
+    title: Quote
+    required: true
+    description: The quote (rich text).
+  pull_quote__attribution:
+    title: Attribution
+    required: false
+    description: Optional attribution (plain text).

--- a/components/pull-quote/pull-quote.twig
+++ b/components/pull-quote/pull-quote.twig
@@ -1,0 +1,23 @@
+{#
+ # SDC thin wrapper for the Pull Quote molecule. Both the quote and the
+ # attribution are rendered field content (rich markup) feeding {{ ... }}
+ # (auto-escaping) sinks, so they are captured as Markup via
+ # {% set %}{{ block()|raw }}{% endset %} to preserve markup without double-
+ # escaping. The attribution is emptied when blank so the template's
+ # `{% if attribution %}` stays falsy (no stray figcaption).
+ # See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set pull_quote__quote %}{{ block('pull_quote__quote')|raw }}{% endset %}
+{% set pull_quote__attribution_captured %}{{ block('pull_quote__attribution')|raw }}{% endset %}
+{% set pull_quote__attribution = pull_quote__attribution_captured|trim is empty ? '' : pull_quote__attribution_captured %}
+{{ include('@molecules/pull-quote/yds-pull-quote.twig', {
+  pull_quote__style: pull_quote__style,
+  pull_quote__width: pull_quote__width,
+  pull_quote__alignment: pull_quote__alignment,
+  pull_quote__quote: pull_quote__quote,
+  pull_quote__attribution: pull_quote__attribution,
+}, with_context = false) }}
+{% if false %}
+  {% block pull_quote__quote %}{% endblock %}
+  {% block pull_quote__attribution %}{% endblock %}
+{% endif %}

--- a/components/quick-links/quick-links.component.yml
+++ b/components/quick-links/quick-links.component.yml
@@ -21,8 +21,11 @@ props:
         - "null"
     quick_links__background_color:
       title: Theme
-      type: string
-      default: one
+      description: Nullable; the template applies its own default ('one') when absent.
+      type:
+        - string
+        - "null"
+
     quick_links__width:
       title: Width
       type:

--- a/components/quick-links/quick-links.component.yml
+++ b/components/quick-links/quick-links.component.yml
@@ -1,0 +1,48 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Quick Links
+status: stable
+group: Molecules
+description: >
+  A promotional/subtle quick-links block (heading, optional description/image,
+  and a list of links). Thin SDC wrapper over
+  @molecules/quick-links/yds-quick-links.twig.
+props:
+  type: object
+  properties:
+    quick_links__variation:
+      title: Variation
+      type: string
+      enum: [promotional, subtle]
+      default: promotional
+    quick_links__heading:
+      title: Heading
+      type:
+        - string
+        - "null"
+    quick_links__background_color:
+      title: Theme
+      type: string
+      default: one
+    quick_links__width:
+      title: Width
+      type:
+        - string
+        - "null"
+    quick_links__alignment:
+      title: Alignment
+      type:
+        - string
+        - "null"
+slots:
+  quick_links__description:
+    title: Description
+    required: false
+    description: Optional description (rendered via the text atom).
+  quick_links__image_slot:
+    title: Image
+    required: false
+    description: Optional image (named __image_slot to avoid the template's image block).
+  quick_links__links_slot:
+    title: Links
+    required: false
+    description: The list of links (named __links_slot to avoid the template's links block).

--- a/components/quick-links/quick-links.twig
+++ b/components/quick-links/quick-links.twig
@@ -1,0 +1,30 @@
+{#
+ # SDC thin wrapper for the Quick Links molecule. description feeds the text atom
+ # (|raw internally, |trim'd for its {% if %}). image and links are optional:
+ # each captured slot both gates the template's {% if %} (derived truthiness) and
+ # supplies content (injected into the matching CLT block). directory threaded.
+ #}
+{% set quick_links__description_slot = block('quick_links__description') %}
+{% set qlimg %}{{ block('quick_links__image_slot')|raw }}{% endset %}
+{% set qllnk %}{{ block('quick_links__links_slot')|raw }}{% endset %}
+{% embed '@molecules/quick-links/yds-quick-links.twig' with {
+  quick_links__variation: quick_links__variation,
+  quick_links__heading: quick_links__heading,
+  quick_links__background_color: quick_links__background_color,
+  quick_links__width: quick_links__width,
+  quick_links__alignment: quick_links__alignment,
+  quick_links__description: quick_links__description_slot|trim,
+  quick_links__image: qlimg|trim is empty ? '' : true,
+  quick_links__links: qllnk|trim is empty ? '' : true,
+  qlimg: qlimg,
+  qllnk: qllnk,
+  directory: directory,
+} only %}
+  {% block quick_links__image %}{{ qlimg|raw }}{% endblock %}
+  {% block quick_links__links %}{{ qllnk|raw }}{% endblock %}
+{% endembed %}
+{% if false %}
+  {% block quick_links__description %}{% endblock %}
+  {% block quick_links__image_slot %}{% endblock %}
+  {% block quick_links__links_slot %}{% endblock %}
+{% endif %}

--- a/components/read-time/read-time.component.yml
+++ b/components/read-time/read-time.component.yml
@@ -1,0 +1,20 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Read Time
+status: stable
+group: Atoms
+description: >
+  An estimated read-time indicator (the minutes value is computed client-side by
+  the component JS). Thin SDC wrapper over @molecules/read-time/yds-read-time.twig;
+  JS attaches via libraryOverrides (atomic/read-time).
+libraryOverrides:
+  dependencies:
+    - atomic/read-time
+props:
+  type: object
+  properties:
+    read_time__label:
+      title: Label
+      description: The label shown before the computed time (defaults to "Estimated read time").
+      type:
+        - string
+        - "null"

--- a/components/read-time/read-time.twig
+++ b/components/read-time/read-time.twig
@@ -1,0 +1,7 @@
+{#
+ # SDC thin wrapper for Read Time. Props-only; the minutes value is filled in by
+ # the component JS (attached via libraryOverrides).
+ #}
+{{ include('@molecules/read-time/yds-read-time.twig', {
+  read_time__label: read_time__label,
+}, with_context = false) }}

--- a/components/taxonomy-display/taxonomy-display.component.yml
+++ b/components/taxonomy-display/taxonomy-display.component.yml
@@ -1,0 +1,28 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Taxonomy Display
+status: stable
+group: Molecules
+description: >
+  Displays taxonomy terms grouped by label. Thin SDC wrapper over
+  @molecules/taxonomy-display/yds-taxonomy-display.twig.
+props:
+  type: object
+  properties:
+    taxonomy_display__theme:
+      title: Theme
+      type: string
+      enum: [default, one, two, three]
+      default: default
+    taxonomy_display__width:
+      title: Width
+      description: Layout width; the template defaults to "site".
+      type:
+        - string
+        - "null"
+slots:
+  taxonomy_display__content:
+    title: Taxonomy content
+    required: true
+    description: >
+      The rendered taxonomy items. Named taxonomy_display__content (not
+      taxonomy_display__items) to avoid a collision with the template's block.

--- a/components/taxonomy-display/taxonomy-display.twig
+++ b/components/taxonomy-display/taxonomy-display.twig
@@ -1,0 +1,13 @@
+{#
+ # SDC thin wrapper for Taxonomy Display. The slot is injected into the
+ # template's taxonomy_display__items block.
+ #}
+{% set taxonomy_display__content = block('taxonomy_display__content') %}
+{% embed '@molecules/taxonomy-display/yds-taxonomy-display.twig' with {
+  taxonomy_display__theme: taxonomy_display__theme,
+  taxonomy_display__width: taxonomy_display__width,
+  taxonomy_display__content: taxonomy_display__content,
+} only %}
+  {% block taxonomy_display__items %}{{ taxonomy_display__content|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block taxonomy_display__content %}{% endblock %}{% endif %}

--- a/components/text-copy-button/text-copy-button.component.yml
+++ b/components/text-copy-button/text-copy-button.component.yml
@@ -1,0 +1,38 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Text Copy Button
+status: stable
+group: Atoms
+description: >
+  A button that copies adjacent text to the clipboard. Thin SDC wrapper over
+  @atoms/controls/text-copy-button/yds-text-copy-button.twig; JS attaches via
+  libraryOverrides (atomic/text-copy-button).
+libraryOverrides:
+  dependencies:
+    - atomic/text-copy-button
+props:
+  type: object
+  properties:
+    text_copy_button__pre_text:
+      title: Pre-text
+      description: The text shown next to the button and copied to the clipboard.
+      type:
+        - string
+        - "null"
+    text_copy_button__pre_text_tag:
+      title: Pre-text wrapper tag
+      description: HTML tag wrapping the pre-text (span default; div for block markup). Nullable; the template applies its own default.
+      type:
+        - string
+        - "null"
+    text_copy_button__component_theme:
+      title: Theme
+      type:
+        - string
+        - "null"
+slots:
+  text_copy_button__content_slot:
+    title: Button content
+    required: true
+    description: >
+      The button content. Named text_copy_button__content_slot (not
+      text_copy_button__content) to avoid a collision with the template's block.

--- a/components/text-copy-button/text-copy-button.twig
+++ b/components/text-copy-button/text-copy-button.twig
@@ -1,0 +1,15 @@
+{#
+ # SDC thin wrapper for the Text Copy Button atom. JS attaches via
+ # libraryOverrides. The slot is injected into the template's
+ # text_copy_button__content block; pre_text is passed as a variable.
+ #}
+{% set text_copy_button__content_slot = block('text_copy_button__content_slot') %}
+{% embed '@atoms/controls/text-copy-button/yds-text-copy-button.twig' with {
+  text_copy_button__pre_text: text_copy_button__pre_text,
+  text_copy_button__pre_text_tag: text_copy_button__pre_text_tag,
+  text_copy_button__component_theme: text_copy_button__component_theme,
+  text_copy_button__content_slot: text_copy_button__content_slot,
+} only %}
+  {% block text_copy_button__content %}{{ text_copy_button__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block text_copy_button__content_slot %}{% endblock %}{% endif %}

--- a/components/text-link/text-link.component.yml
+++ b/components/text-link/text-link.component.yml
@@ -1,0 +1,37 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Text Link
+status: stable
+group: Atoms
+description: >
+  A text hyperlink with type/style variants. Thin SDC wrapper over
+  @atoms/controls/text-link/yds-text-link.twig; the real template and SCSS stay
+  in component-library-twig. Web Component candidate (Wave 10).
+props:
+  type: object
+  properties:
+    link__url:
+      title: URL
+      type:
+        - string
+        - "null"
+    link__type:
+      title: Link type
+      description: Link treatment; external/target-blank/download/with-chevron add an icon.
+      type: string
+      enum: [normal, download, external, target-blank, with-chevron]
+      default: normal
+    link__style:
+      title: Link style
+      description: >
+        Underline treatment. NOTE the source template reads this as `link_style`
+        (single underscore) — the shim maps link__style onto it.
+      type: string
+      enum: [underline, no-underline, no-animation]
+      default: underline
+slots:
+  link__content_slot:
+    title: Link content
+    required: true
+    description: >
+      The link content. Named link__content_slot (not link__content) to avoid a
+      collision with the template's own link__content block.

--- a/components/text-link/text-link.twig
+++ b/components/text-link/text-link.twig
@@ -1,0 +1,16 @@
+{#
+ # SDC thin wrapper for the Text Link atom. The slot is injected into the
+ # template's link__content block; link__style is mapped onto the template's
+ # `link_style` variable (source uses a single underscore).
+ # See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set link__content_slot = block('link__content_slot') %}
+{% embed '@atoms/controls/text-link/yds-text-link.twig' with {
+  link__url: link__url,
+  link__type: link__type,
+  link_style: link__style,
+  link__content_slot: link__content_slot,
+} only %}
+  {% block link__content %}{{ link__content_slot|trim|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block link__content_slot %}{% endblock %}{% endif %}

--- a/components/text/text.component.yml
+++ b/components/text/text.component.yml
@@ -1,0 +1,26 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Text
+status: stable
+group: Atoms
+description: >
+  Rich-text / body-copy wrapper. Thin SDC wrapper over
+  @atoms/typography/text/yds-text.twig; the real template and SCSS stay in
+  component-library-twig.
+props:
+  type: object
+  properties:
+    text__element:
+      title: Wrapper element
+      description: The HTML element to wrap the content in (div, p, pre, ...).
+      type: string
+      default: div
+      examples:
+        - div
+        - p
+slots:
+  text__content:
+    title: Content
+    required: true
+    description: >
+      The rich-text content. The underlying template prints it with |raw to
+      support WYSIWYG output, so pass already-sanitized Drupal content.

--- a/components/text/text.twig
+++ b/components/text/text.twig
@@ -1,0 +1,11 @@
+{#
+ # SDC thin wrapper for the Text atom. The CLT template consumes text__content
+ # as a *variable* (printed with |raw), so the captured slot is passed through
+ # as text__content. See docs/sdc/recipe-convert-a-component-to-sdc.md.
+ #}
+{% set text__content_slot = block('text__content') %}
+{{ include('@atoms/typography/text/yds-text.twig', {
+  text__element: text__element,
+  text__content: text__content_slot|trim,
+}, with_context = false) }}
+{% if false %}{% block text__content %}{% endblock %}{% endif %}

--- a/components/wrapped-callout/wrapped-callout.component.yml
+++ b/components/wrapped-callout/wrapped-callout.component.yml
@@ -1,0 +1,37 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Wrapped Callout
+status: stable
+group: Molecules
+description: >
+  A callout text wrapped alongside body text. Thin SDC wrapper over
+  @molecules/wrapped-callout/yds-wrapped-callout.twig.
+props:
+  type: object
+  properties:
+    wrapped_callout__theme:
+      title: Theme (dial)
+      description: field_style_color (list_key).
+      type: string
+      enum: [one, two, three, four, five]
+      default: one
+    wrapped_callout__alignment:
+      title: Alignment (dial)
+      description: field_style_position (list_key).
+      type: string
+      enum: [left, right]
+      default: left
+    wrapped_callout__width:
+      title: Width
+      description: Content width; computed by the block template from the parent node type.
+      type:
+        - string
+        - "null"
+slots:
+  wrapped_callout__callout:
+    title: Callout text
+    required: false
+    description: The emphasized callout text (rendered via the text atom).
+  wrapped_callout__content:
+    title: Body text
+    required: false
+    description: The body text (rendered via the text atom).

--- a/components/wrapped-callout/wrapped-callout.twig
+++ b/components/wrapped-callout/wrapped-callout.twig
@@ -1,0 +1,18 @@
+{#
+ # SDC thin wrapper for the Wrapped Callout molecule. Both slots feed the text
+ # atom (which prints with |raw), so a plain |trim capture is safe and keeps an
+ # empty slot falsy for the template's {% if %} checks.
+ #}
+{% set wrapped_callout__callout_slot = block('wrapped_callout__callout') %}
+{% set wrapped_callout__content_slot = block('wrapped_callout__content') %}
+{{ include('@molecules/wrapped-callout/yds-wrapped-callout.twig', {
+  wrapped_callout__width: wrapped_callout__width,
+  wrapped_callout__alignment: wrapped_callout__alignment,
+  wrapped_callout__theme: wrapped_callout__theme,
+  wrapped_callout__callout: wrapped_callout__callout_slot|trim,
+  wrapped_callout__content: wrapped_callout__content_slot|trim,
+}, with_context = false) }}
+{% if false %}
+  {% block wrapped_callout__callout %}{% endblock %}
+  {% block wrapped_callout__content %}{% endblock %}
+{% endif %}

--- a/components/wrapped-image/wrapped-image.component.yml
+++ b/components/wrapped-image/wrapped-image.component.yml
@@ -1,0 +1,41 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Wrapped Image
+status: stable
+group: Molecules
+description: >
+  An image floated/offset alongside wrapping text. Thin SDC wrapper over
+  @molecules/wrapped-image/yds-wrapped-image.twig.
+props:
+  type: object
+  properties:
+    wrapped_image__style:
+      title: Style (dial)
+      description: field_style_variation (list_key).
+      type: string
+      enum: [floated, offset]
+      default: offset
+    wrapped_image__alignment:
+      title: Image alignment (dial)
+      description: field_style_position (list_key).
+      type: string
+      enum: [left, right]
+      default: left
+    wrapped_image__width:
+      title: Width
+      description: Content width; computed by the block template from the parent node type.
+      type:
+        - string
+        - "null"
+slots:
+  wrapped_image__content:
+    title: Wrapping text
+    required: false
+    description: The text that wraps the image (rendered via the text atom).
+  wrapped_image__caption:
+    title: Image caption
+    required: false
+    description: Optional image caption.
+  wrapped_image__image:
+    title: Image markup
+    required: true
+    description: The image markup (typically a Drupal media/responsive-image render array).

--- a/components/wrapped-image/wrapped-image.twig
+++ b/components/wrapped-image/wrapped-image.twig
@@ -1,0 +1,26 @@
+{#
+ # SDC thin wrapper for the Wrapped Image molecule. content -> text atom and
+ # caption -> image atom figure__caption both print with |raw internally, so a
+ # plain capture is safe (caption |trim'd so an empty caption stays falsy). The
+ # image markup is injected into the wrapped_image__image block. directory is
+ # threaded for nested asset paths.
+ #}
+{% set wrapped_image__content_slot = block('wrapped_image__content') %}
+{% set wrapped_image__caption_slot = block('wrapped_image__caption') %}
+{% set wrapped_image__image_slot %}{{ block('wrapped_image__image')|raw }}{% endset %}
+{% embed '@molecules/wrapped-image/yds-wrapped-image.twig' with {
+  wrapped_image__style: wrapped_image__style,
+  wrapped_image__alignment: wrapped_image__alignment,
+  wrapped_image__width: wrapped_image__width,
+  wrapped_image__content: wrapped_image__content_slot,
+  wrapped_image__caption: wrapped_image__caption_slot|trim,
+  wrapped_image__image_slot: wrapped_image__image_slot,
+  directory: directory,
+} only %}
+  {% block wrapped_image__image %}{{ wrapped_image__image_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}
+  {% block wrapped_image__content %}{% endblock %}
+  {% block wrapped_image__caption %}{% endblock %}
+  {% block wrapped_image__image %}{% endblock %}
+{% endif %}

--- a/templates/block/layout-builder/block--inline-block--accordion.html.twig
+++ b/templates/block/layout-builder/block--inline-block--accordion.html.twig
@@ -2,8 +2,8 @@
 
 {% block content %}
 
-  {{ attach_library('atomic/accordion') }}
-
+  {# accordion__alignment and accordion__width are derived from the parent node
+     type, not a dial. #}
   {% if parentNode == 'post' or parentNode == 'event' %}
     {% set accordion__width = "content" %}
     {% set accordion__alignment = "center" %}
@@ -12,14 +12,16 @@
     {% set accordion__alignment = "left" %}
   {% endif %}
 
-  {% embed "@molecules/accordion/yds-accordion.twig" with {
-    accordion__heading: content.field_heading.0,
+  {# JS/CSS attach via the SDC's libraryOverrides (atomic/accordion); no manual
+     attach_library() needed. No `only`: the slot block overrides reference
+     `content`, and `directory` must flow into the SDC for the nested icon. #}
+  {% embed 'atomic:accordion' with {
     accordion__alignment: accordion__alignment,
-    accordion__theme: content.field_style_color.0['#markup'],
+    accordion__width: accordion__width,
+    accordion__theme: content.field_style_color.0['#markup']|default('default'),
   } %}
-    {% block accordion__items %}
-      {{ content.field_accordion_items }}
-    {% endblock %}
+    {% block accordion__heading %}{{ content.field_heading.0 }}{% endblock %}
+    {% block accordion__content %}{{ content.field_accordion_items }}{% endblock %}
   {% endembed %}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--callout.html.twig
+++ b/templates/block/layout-builder/block--inline-block--callout.html.twig
@@ -1,12 +1,16 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
-  {% embed "@molecules/callout/yds-callout.twig" with {
-      callout__background_color: content.field_style_color.0['#markup'],
-      callout__alignment: content.field_style_alignment.0['#markup'],
+  {# No `only`: the slot block override references `content`, and `directory`
+     must flow into the SDC so nested atoms resolve asset paths. Dial values are
+     defaulted here (adapter layer) because older blocks can store NULL and the
+     SDC schema enums are strict. #}
+  {% embed 'atomic:callout' with {
+      callout__background_color: content.field_style_color.0['#markup']|default('one'),
+      callout__alignment: content.field_style_alignment.0['#markup']|default('center'),
       callout__overlay_background_image: content.field_overlay_background_image.0['#media'].field_media_image.entity.fileuri|file_url,
   } %}
-    {% block callout__items %}
+    {% block callout__content %}
       {{ content.field_callout }}
     {% endblock %}
   {% endembed %}

--- a/templates/block/layout-builder/block--inline-block--divider.html.twig
+++ b/templates/block/layout-builder/block--inline-block--divider.html.twig
@@ -2,9 +2,13 @@
 
 {% block content %}
 
-  {% include "@atoms/divider/yds-divider.twig" with {
-    divider__position: content.field_style_position.0['#markup'],
-    divider__width: content.field_style_width.0['#markup'],
-  } %}
+  {# Default dial values here (the adapter layer): older blocks can store NULL,
+     and the SDC schema enums are strict. 'Center' matches the pre-SDC behavior
+     for a NULL position (the CLT template lowercased its own 'center' default)
+     and aligns with the schema default. #}
+  {{ include('atomic:divider', {
+    divider__position: content.field_style_position.0['#markup']|default('Center'),
+    divider__width: content.field_style_width.0['#markup']|default('100'),
+  }, with_context = false) }}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--inline-message.html.twig
+++ b/templates/block/layout-builder/block--inline-block--inline-message.html.twig
@@ -2,19 +2,15 @@
 
 {% block content %}
 
-  {% if parentNode == 'post' or parentNode == 'event' %}
-    {% set inline_message__width = "content" %}
-    {% set inline_message__alignment = "center" %}
-  {% else %}
-    {% set inline_message__width = "site" %}
-    {% set inline_message__alignment = "left" %}
-  {% endif %}
-
-  {% include "@molecules/inline-message/yds-inline-message.twig" with {
-    inline_message__heading: content.field_heading.0,
-    inline_message__content: content.field_text.0,
+  {# No `only`: the slot block overrides reference `content`, and `directory`
+     must flow into the SDC for the nested icon. #}
+  {% embed 'atomic:inline-message' with {
+    inline_message__theme: content.field_style_color.0['#markup']|default('one'),
     inline_message__link__content: content.field_link.0['#title'],
     inline_message__link__url: content.field_link.0['#url_title'],
-    inline_message__theme: content.field_style_color.0['#markup'],
   } %}
+    {% block inline_message__heading %}{{ content.field_heading.0 }}{% endblock %}
+    {% block inline_message__content %}{{ content.field_text.0 }}{% endblock %}
+  {% endembed %}
+
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--link-grid.html.twig
+++ b/templates/block/layout-builder/block--inline-block--link-grid.html.twig
@@ -11,34 +11,19 @@
   {% if layout_section == 'ys_layout_two_column_50_50' %}
     {% set link_grid_theme = 'inherit' %}
   {% else %}
-    {% set link_grid_theme = content.field_style_color.0['#markup'] %}
+    {% set link_grid_theme = content.field_style_color.0['#markup']|default('one') %}
   {% endif %}
 
-  {# add checks for each link list #}
-  {% set link_grid__links_one = content.field_link_lists.0 %}
-  {% set link_grid__links_two = content.field_link_lists.1 %}
-  {% set link_grid__links_three = content.field_link_lists.2 %}
-  {% set link_grid__links_four = content.field_link_lists.3 %}
-
-  {% set link_grid__line_treatment = link_grid__line_treatment|default('default') %}
-
-  {% embed "@molecules/link-grid/yds-link-grid.twig" with {
+  {% embed 'atomic:link-grid' with {
     link_grid__theme: link_grid_theme,
-    link_grid__heading: content.field_heading.0,
-    link_grid__line_treatment: link_grid__line_treatment,
-  }%}
-    {% block link_grid__links_one %}
-      {{content.field_link_lists.0}}
-    {% endblock %}
-    {% block link_grid__links_two %}
-      {{content.field_link_lists.1}}
-    {% endblock %}
-    {% block link_grid__links_three %}
-      {{content.field_link_lists.2}}
-    {% endblock %}
-    {% block link_grid__links_four %}
-      {{content.field_link_lists.3}}
-    {% endblock %}
+    link_grid__width: link_grid__width,
+    link_grid__line_treatment: 'default',
+  } %}
+    {% block link_grid__heading %}{{ content.field_heading.0 }}{% endblock %}
+    {% block link_grid__col_one %}{{ content.field_link_lists.0 }}{% endblock %}
+    {% block link_grid__col_two %}{{ content.field_link_lists.1 }}{% endblock %}
+    {% block link_grid__col_three %}{{ content.field_link_lists.2 }}{% endblock %}
+    {% block link_grid__col_four %}{{ content.field_link_lists.3 }}{% endblock %}
   {% endembed %}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--pull-quote.html.twig
+++ b/templates/block/layout-builder/block--inline-block--pull-quote.html.twig
@@ -1,18 +1,22 @@
 {% extends "@atomic/block/layout-builder/_layout-builder-block-template.twig" %}
 
 {% block content %}
-    {% if parentNode == 'post' or parentNode == 'event' %}
-      {% set pull_quote__width = "content" %}
-      {% set pull_quote__alignment = "center" %}
-    {% else %}
-      {% set pull_quote__width = "site" %}
-      {% set pull_quote__alignment = "left" %}
+  {# width/alignment are derived from the parent node type (as in the pre-SDC
+     template, where they reached the component via include context). #}
+  {% if parentNode == 'post' or parentNode == 'event' %}
+    {% set pull_quote__width = "content" %}
+    {% set pull_quote__alignment = "center" %}
+  {% else %}
+    {% set pull_quote__width = "site" %}
+    {% set pull_quote__alignment = "left" %}
   {% endif %}
 
-  {% include "@molecules/pull-quote/yds-pull-quote.twig" with {
-    pull_quote__quote: content.field_text,
-    pull_quote__attribution: content.field_caption.0,
-    pull_quote__style: content.field_style_variation.0['#markup'],
+  {% embed 'atomic:pull-quote' with {
+    pull_quote__style: content.field_style_variation.0['#markup']|default('bar-left'),
+    pull_quote__width: pull_quote__width,
+    pull_quote__alignment: pull_quote__alignment,
   } %}
-
+    {% block pull_quote__quote %}{{ content.field_text }}{% endblock %}
+    {% block pull_quote__attribution %}{{ content.field_caption.0 }}{% endblock %}
+  {% endembed %}
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--quick-links.html.twig
+++ b/templates/block/layout-builder/block--inline-block--quick-links.html.twig
@@ -10,23 +10,15 @@
     {% set quick_links__alignment = "left" %}
   {% endif %}
 
-  {% embed "@molecules/quick-links/yds-quick-links.twig" with {
+  {% embed 'atomic:quick-links' with {
     quick_links__variation: 'promotional',
     quick_links__heading: content.field_heading.0['#text'],
-    quick_links__description: content.field_text.0,
-    quick_links__image: content.field_media.0,
-    quick_links__links: content.field_links.0,
+    quick_links__width: quick_links__width,
     quick_links__alignment: quick_links__alignment,
   } %}
-
-    {% block quick_links__links %}
-      {{ content.field_links }}
-    {% endblock %}
-
-    {% block quick_links__image %}
-      {{ content.field_media }}
-    {% endblock %}
-
+    {% block quick_links__description %}{{ content.field_text.0 }}{% endblock %}
+    {% block quick_links__image_slot %}{{ content.field_media }}{% endblock %}
+    {% block quick_links__links_slot %}{{ content.field_links }}{% endblock %}
   {% endembed %}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--wrapped-image.html.twig
+++ b/templates/block/layout-builder/block--inline-block--wrapped-image.html.twig
@@ -8,18 +8,15 @@
     {% set wrapped_image__width = "site" %}
   {% endif %}
 
-  {% embed "@molecules/wrapped-image/yds-wrapped-image.twig" with {
-    wrapped_image__style: content.field_style_variation.0['#markup'],
-    wrapped_image__alignment: content.field_style_position.0['#markup'],
-    wrapped_image__content: content.field_text.0,
-    wrapped_image__caption: content.field_caption.0,
+  {# No `only`: slot overrides reference `content`, and `directory` must flow in. #}
+  {% embed 'atomic:wrapped-image' with {
+    wrapped_image__style: content.field_style_variation.0['#markup']|default('offset'),
+    wrapped_image__alignment: content.field_style_position.0['#markup']|default('left'),
     wrapped_image__width: wrapped_image__width|default('content'),
   } %}
-
-    {% block wrapped_image__image %}
-      {{ content.field_media }}
-    {% endblock %}
-
+    {% block wrapped_image__content %}{{ content.field_text.0 }}{% endblock %}
+    {% block wrapped_image__caption %}{{ content.field_caption.0 }}{% endblock %}
+    {% block wrapped_image__image %}{{ content.field_media }}{% endblock %}
   {% endembed %}
 
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--wrapped-text-callout.html.twig
+++ b/templates/block/layout-builder/block--inline-block--wrapped-text-callout.html.twig
@@ -8,13 +8,13 @@
     {% set wrapped_callout__width = "site" %}
   {% endif %}
 
-  {% embed "@molecules/wrapped-callout/yds-wrapped-callout.twig" with {
+  {% embed 'atomic:wrapped-callout' with {
     wrapped_callout__width: wrapped_callout__width|default('content'),
-    wrapped_callout__callout: content.field_callout_text.0,
-    wrapped_callout__content: content.field_text.0,
-    wrapped_callout__alignment: content.field_style_position.0['#markup'],
-    wrapped_callout__theme: content.field_style_color.0['#markup'],
+    wrapped_callout__alignment: content.field_style_position.0['#markup']|default('left'),
+    wrapped_callout__theme: content.field_style_color.0['#markup']|default('one'),
   } %}
+    {% block wrapped_callout__callout %}{{ content.field_callout_text.0 }}{% endblock %}
+    {% block wrapped_callout__content %}{{ content.field_text.0 }}{% endblock %}
   {% endembed %}
 
 {% endblock %}

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -205,4 +205,17 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertSame([], $this->validate('basic-meta', []));
   }
 
+  /**
+   * Inline Message (Wave 2): a valid theme/type passes; an invalid theme fails.
+   */
+  public function testInlineMessage(): void {
+    $this->assertSame([], $this->validate('inline-message', [
+      'inline_message__theme' => 'two',
+      'inline_message__type' => 'marketing',
+    ]));
+    $this->assertNotEmpty($this->validate('inline-message', [
+      'inline_message__theme' => 'nope',
+    ]));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -248,4 +248,13 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('wrapped-callout', ['wrapped_callout__theme' => 'nope']));
   }
 
+  /**
+   * Link Grid (Wave 2): valid themes (incl. "inherit") pass; invalid fails.
+   */
+  public function testLinkGrid(): void {
+    $this->assertSame([], $this->validate('link-grid', ['link_grid__theme' => 'three']));
+    $this->assertSame([], $this->validate('link-grid', ['link_grid__theme' => 'inherit']));
+    $this->assertNotEmpty($this->validate('link-grid', ['link_grid__theme' => 'nope']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -39,7 +39,9 @@ class SdcSchemaValidationTest extends UnitTestCase {
    */
   private function validate(string $name, array $data): array {
     $validator = new Validator();
-    $subject = json_decode(json_encode($data));
+    // Cast to object so an empty prop set encodes as {} (a JSON object) rather
+    // than [] (a JSON array), which would fail the schema's "type: object".
+    $subject = json_decode(json_encode((object) $data));
     $validator->validate($subject, $this->propsSchema($name));
     return $validator->getErrors();
   }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -237,4 +237,15 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('wrapped-image', ['wrapped_image__style' => 'nope']));
   }
 
+  /**
+   * Wrapped Callout (Wave 2): valid dials pass; an invalid theme fails.
+   */
+  public function testWrappedCallout(): void {
+    $this->assertSame([], $this->validate('wrapped-callout', [
+      'wrapped_callout__theme' => 'two',
+      'wrapped_callout__alignment' => 'right',
+    ]));
+    $this->assertNotEmpty($this->validate('wrapped-callout', ['wrapped_callout__theme' => 'nope']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\Tests\atomic\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use JsonSchema\Validator;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Validates SDC component prop schemas against sample data.
+ *
+ * This is the lightweight, mechanical schema-validation pattern every wave of
+ * the SDC migration (epic #1351) reuses: valid data passes, invalid data (wrong
+ * enum / missing required) fails predictably. It uses justinrainbow/json-schema
+ * (available via drupal/core-dev) directly against the props schema authored in
+ * each *.component.yml, so it needs no Drupal bootstrap and runs fast in CI.
+ *
+ * Render-level enforcement (that SDC actually applies these schemas when
+ * assertions are on) is covered by the Kernel test.
+ *
+ * @group yalesites
+ * @group sdc
+ */
+class SdcSchemaValidationTest extends UnitTestCase {
+
+  /**
+   * Loads the props schema from a component's *.component.yml.
+   */
+  private function propsSchema(string $name): object {
+    $file = __DIR__ . "/../../../components/$name/$name.component.yml";
+    $this->assertFileExists($file, "component.yml for $name should exist");
+    $meta = Yaml::parseFile($file);
+    // Convert the parsed props array to the stdClass shape json-schema expects.
+    return json_decode(json_encode($meta['props']));
+  }
+
+  /**
+   * Validates $data against a component's props schema; returns error array.
+   */
+  private function validate(string $name, array $data): array {
+    $validator = new Validator();
+    $subject = json_decode(json_encode($data));
+    $validator->validate($subject, $this->propsSchema($name));
+    return $validator->getErrors();
+  }
+
+  /**
+   * Divider: the cheap case. Valid width/position pass.
+   */
+  public function testDividerValidData(): void {
+    $this->assertSame([], $this->validate('divider', [
+      'divider__width' => '50',
+      'divider__position' => 'Left',
+    ]));
+  }
+
+  /**
+   * Divider: an out-of-enum width fails predictably.
+   */
+  public function testDividerInvalidWidthFails(): void {
+    $this->assertNotEmpty($this->validate('divider', [
+      'divider__width' => '999',
+    ]));
+  }
+
+  /**
+   * Callout: a valid dial value passes.
+   */
+  public function testCalloutValidDial(): void {
+    $this->assertSame([], $this->validate('callout', [
+      'callout__background_color' => 'three',
+      'callout__alignment' => 'left',
+    ]));
+  }
+
+  /**
+   * Callout: an invalid dial value fails.
+   *
+   * This is the no-drift enforcement, proven at the schema level (render-level
+   * enforcement is covered separately).
+   */
+  public function testCalloutInvalidDialFails(): void {
+    $this->assertNotEmpty($this->validate('callout', [
+      'callout__background_color' => 'not-a-real-theme',
+      'callout__alignment' => 'center',
+    ]));
+  }
+
+  /**
+   * Accordion: a valid dial value passes.
+   */
+  public function testAccordionValidDial(): void {
+    $this->assertSame([], $this->validate('accordion', [
+      'accordion__theme' => 'default',
+      'accordion__alignment' => 'left',
+      'accordion__width' => 'content',
+    ]));
+  }
+
+}

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -218,4 +218,12 @@ class SdcSchemaValidationTest extends UnitTestCase {
     ]));
   }
 
+  /**
+   * Pull Quote (Wave 2): a valid style passes; an invalid one fails.
+   */
+  public function testPullQuoteStyle(): void {
+    $this->assertSame([], $this->validate('pull-quote', ['pull_quote__style' => 'quote-left']));
+    $this->assertNotEmpty($this->validate('pull-quote', ['pull_quote__style' => 'nope']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -226,4 +226,15 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('pull-quote', ['pull_quote__style' => 'nope']));
   }
 
+  /**
+   * Wrapped Image (Wave 2): valid dials pass; an invalid style fails.
+   */
+  public function testWrappedImage(): void {
+    $this->assertSame([], $this->validate('wrapped-image', [
+      'wrapped_image__style' => 'floated',
+      'wrapped_image__alignment' => 'right',
+    ]));
+    $this->assertNotEmpty($this->validate('wrapped-image', ['wrapped_image__style' => 'nope']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -257,4 +257,12 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('link-grid', ['link_grid__theme' => 'nope']));
   }
 
+  /**
+   * Quick Links (Wave 2): a valid variation passes; an invalid one fails.
+   */
+  public function testQuickLinks(): void {
+    $this->assertSame([], $this->validate('quick-links', ['quick_links__variation' => 'subtle']));
+    $this->assertNotEmpty($this->validate('quick-links', ['quick_links__variation' => 'nope']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -144,4 +144,12 @@ class SdcSchemaValidationTest extends UnitTestCase {
     ]));
   }
 
+  /**
+   * Lists atom (Wave 1, codegen-seeded): a valid type passes; invalid fails.
+   */
+  public function testListsType(): void {
+    $this->assertSame([], $this->validate('lists', ['list__type' => 'ol']));
+    $this->assertNotEmpty($this->validate('lists', ['list__type' => 'table']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -118,4 +118,30 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('heading', ['heading__level' => '9']));
   }
 
+  /**
+   * CTA atom (Wave 1): a valid fill style passes; an invalid one fails.
+   */
+  public function testCtaStyle(): void {
+    $this->assertSame([], $this->validate('cta', ['cta__style' => 'outline']));
+    $this->assertNotEmpty($this->validate('cta', ['cta__style' => 'bogus']));
+  }
+
+  /**
+   * Text Link atom (Wave 1): a valid type passes; an invalid one fails.
+   */
+  public function testTextLinkType(): void {
+    $this->assertSame([], $this->validate('text-link', ['link__type' => 'external']));
+    $this->assertNotEmpty($this->validate('text-link', ['link__type' => 'bogus']));
+  }
+
+  /**
+   * Text Copy Button atom (Wave 1): valid data (with an optional tag) passes.
+   */
+  public function testTextCopyButtonValid(): void {
+    $this->assertSame([], $this->validate('text-copy-button', [
+      'text_copy_button__pre_text' => 'copy me',
+      'text_copy_button__pre_text_tag' => 'span',
+    ]));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -188,4 +188,12 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('taxonomy-display', ['taxonomy_display__theme' => 'nope']));
   }
 
+  /**
+   * Image atom (Wave 1): valid data (with an optional caption) passes.
+   */
+  public function testImageValid(): void {
+    $this->assertSame([], $this->validate('image', ['figure__caption' => 'A caption']));
+    $this->assertSame([], $this->validate('image', ['figure__caption' => NULL]));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -152,4 +152,18 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('lists', ['list__type' => 'table']));
   }
 
+  /**
+   * Date Time atom (Wave 1): a valid format passes; an invalid one fails.
+   */
+  public function testDateTimeFormat(): void {
+    $this->assertSame([], $this->validate('date-time', [
+      'date_time__start' => 1700000000,
+      'date_time__format' => 'date',
+    ]));
+    $this->assertNotEmpty($this->validate('date-time', [
+      'date_time__start' => 1700000000,
+      'date_time__format' => 'bogus',
+    ]));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -196,4 +196,11 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertSame([], $this->validate('image', ['figure__caption' => NULL]));
   }
 
+  /**
+   * Basic Meta (Wave 1): the (prop-less) schema accepts an empty prop set.
+   */
+  public function testBasicMetaValid(): void {
+    $this->assertSame([], $this->validate('basic-meta', []));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -166,4 +166,18 @@ class SdcSchemaValidationTest extends UnitTestCase {
     ]));
   }
 
+  /**
+   * Skip Link atom (Wave 1): valid data passes.
+   */
+  public function testLinkSkipValid(): void {
+    $this->assertSame([], $this->validate('link-skip', ['link_skip__url' => '#main']));
+  }
+
+  /**
+   * Read Time atom (Wave 1): valid data passes.
+   */
+  public function testReadTimeValid(): void {
+    $this->assertSame([], $this->validate('read-time', ['read_time__label' => 'Read time']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -97,4 +97,25 @@ class SdcSchemaValidationTest extends UnitTestCase {
     ]));
   }
 
+  /**
+   * Text atom (Wave 1): a valid wrapper element passes.
+   */
+  public function testTextValidData(): void {
+    $this->assertSame([], $this->validate('text', ['text__element' => 'p']));
+  }
+
+  /**
+   * Heading atom (Wave 1): a valid level passes.
+   */
+  public function testHeadingValidLevel(): void {
+    $this->assertSame([], $this->validate('heading', ['heading__level' => '3']));
+  }
+
+  /**
+   * Heading atom (Wave 1): an out-of-range level fails.
+   */
+  public function testHeadingInvalidLevelFails(): void {
+    $this->assertNotEmpty($this->validate('heading', ['heading__level' => '9']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -180,4 +180,12 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertSame([], $this->validate('read-time', ['read_time__label' => 'Read time']));
   }
 
+  /**
+   * Taxonomy Display (Wave 1): a valid theme passes; an invalid one fails.
+   */
+  public function testTaxonomyDisplayTheme(): void {
+    $this->assertSame([], $this->validate('taxonomy-display', ['taxonomy_display__theme' => 'one']));
+    $this->assertNotEmpty($this->validate('taxonomy-display', ['taxonomy_display__theme' => 'nope']));
+  }
+
 }


### PR DESCRIPTION
## [1355: Wave 2: Static presentational molecules (no JS)](https://github.com/yalesites-org/YaleSites-Internal/issues/1355)

Wave 2 of the SDC migration (epic yalesites-org/YaleSites-Internal#1351). Static presentational molecules — in the Layout Builder render path (block templates repointed), so each is baseline-verified on a real page.

> **Stacked on #1354** (Wave 1). Merge yalesites-org/atomic#474 first; until then this PR's diff includes Waves 0–1.
> **Partial wave** — the two below are done + verified; the rest of the static molecules follow.

### Converted + baseline-verified (renders normalized-identical to the pre-SDC output on a real page)
- **inline-message** — theme dial + heading/content variable-slots; verified on `/resource-test`.
- **pull-quote** — style dial + width/alignment; quote & attribution captured as **Markup** to preserve rich field markup in the auto-escaping blockquote/figcaption (with an emptiness guard); verified on `/welcome/centering-inclusivity`.

Two real defects were caught by the baseline diffs and fixed (a dropped context-inherited `width`, and double-escaped rich attribution) — see the recipe update in the companion CLT PR.

### Companion work
Recipe refinements in yalesites-org/component-library-twig#TBD; multidev trigger in yalesites-org/yalesites-project#TBD.

References yalesites-org/YaleSites-Internal#1355