### PR TITLE
1241: Publication/Resource image shows filename as alt text on resource detail page

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -228,6 +228,7 @@ function atomic_preprocess_node(&$variables) {
     }
 
     // Create responsive_image render array using the thumbnail uri.
+    $alt = \Drupal::service('ys_layouts.media_alt_resolver')->resolve($media);
     $variables['responsive_media_thumbnail'] = [
       '#theme' => 'responsive_image',
       '#uri' => $file->getFileUri(),
@@ -236,7 +237,7 @@ function atomic_preprocess_node(&$variables) {
       '#width' => $thumbnail?->width,
       '#attributes' => [
         'loading' => 'lazy',
-        'alt' => $media->label(),
+        'alt' => $alt,
       ],
     ];
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,9 +2087,9 @@
       "inBundle": true
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.79.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.79.0/d2ce5cf9c3012fb8ffbfdb0fae9921c844d4afde",
-      "integrity": "sha512-BPNVHvyVye/aTZ5u2t5FplGue9jwW3IjPG0IYtQIWbIF9F8x/DMuq3Z6kt2/ZK1eA1gLAG0NWMSpE1ihW5rnxA==",
+      "version": "1.79.1",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.79.1/98a091c253efcc019390c72c1fc8c39616abb6db",
+      "integrity": "sha512-F8TaOBTVwcQohJFzTu2GJu9CmvodEjkJKC3dzy3ZH++LQ69brmloR8O9lXkGtxLCAyv3Nf6RbIc/m3RPK3H+ew==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {

--- a/templates/ys_embed/embed_wrapper.html.twig
+++ b/templates/ys_embed/embed_wrapper.html.twig
@@ -14,6 +14,8 @@
         } %}
         {% endembed %}
     </div>
+{% elseif title|trim != '' %}
+    <div role="group" aria-label="{{ title }}">{{ embedSource }}</div>
 {% else %}
     {{ embedSource }}
 {% endif %}


### PR DESCRIPTION
## [1241: Publication/Resource image shows filename as alt text on resource detail page](https://github.com/yalesites-org/YaleSites-Internal/issues/1241)

### Description of work
- Fix the resource card/list fallback thumbnail in `atomic_preprocess_node()` so it uses the alt text configured on the media's image field instead of the media name (the uploaded filename). Same accessibility bug as the detail page, hit when a resource has no Teaser Media set.
- Derive the alt via the shared `ys_layouts.media_alt_resolver` service so the card fallback matches the detail-page block exactly.
- Other work completed in: yalesites-org/yalesites-project#1323

### Functional testing steps:
- [ ] On a multidev built from the matching `1241-resource-image-alt-text` branches, create/edit a Resource whose Resource Media is an image with a configured alt different from the file name, and leave Teaser Media empty.
- [ ] Place that Resource in a listing that renders it as a card (card / portrait-grid view mode).
- [ ] Inspect the card cover image in dev tools; confirm `alt` shows the configured alt, not the filename.
- [ ] Confirm a blank-alt image renders `alt=""` and a PDF/document resource card still shows a sensible description.

References yalesites-org/YaleSites-Internal#1241
