### PR TITLE
Hotfix 1: 2.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,9 +2087,9 @@
       "inBundle": true
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.79.1",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.79.1/98a091c253efcc019390c72c1fc8c39616abb6db",
-      "integrity": "sha512-F8TaOBTVwcQohJFzTu2GJu9CmvodEjkJKC3dzy3ZH++LQ69brmloR8O9lXkGtxLCAyv3Nf6RbIc/m3RPK3H+ew==",
+      "version": "1.79.2",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.79.2/fd6651a4671b367b3802c0db10ef210e7d5884da",
+      "integrity": "sha512-OB0BW+dh+HxzIPOBUyLoPLSSwGCaRXXdMdwFiBIEXx2GPPvJ+ZeShGR6zG6oVbnvmeRkcR4htwPQ8CeKm6e59Q==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {


### PR DESCRIPTION
## Hotfix: 2.23.0

This merges `develop` into `main` for the atomic portion of the YaleSites 2.23.0
hotfix (part of the chain: component-library-twig -> atomic -> yalesites-project).

The following pull request is being merged in so you can see what's being updated:

- #483 — Bump CL to 1.79.2 (pulls in the component-library-twig hotfix for yalesites-org/YaleSites-Internal#1374)