### PR TITLE
1351: Wave 6 — repoint view + resource-view blocks to component-wrapper SDC

### DIFF
--- a/templates/block/layout-builder/block--inline-block--resource-view.html.twig
+++ b/templates/block/layout-builder/block--inline-block--resource-view.html.twig
@@ -10,11 +10,13 @@
   } %}
 
   <div {{ add_attributes(view__attibutes) }}>
-    {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
+    {% embed 'atomic:component-wrapper' with {
       component_wrapper__width: component_wrapper__width|default('site'),
+      component_wrapper__alignment: 'center',
+      component_wrapper__heading__level: '2',
       component_wrapper__label: content.field_heading.0 ? content.field_heading : '',
       }%}
-      {% block component_wrapper_inner %}
+      {% block inner %}
         {# {% if content.field_heading_links.0 %}
           <div class="cta-group">
             {{ content.field_heading_links|children }}

--- a/templates/block/layout-builder/block--inline-block--view.html.twig
+++ b/templates/block/layout-builder/block--inline-block--view.html.twig
@@ -19,11 +19,13 @@
   {% endif %}
 
   <div {{ add_attributes(view__attibutes) }}>
-    {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
+    {% embed 'atomic:component-wrapper' with {
       component_wrapper__width: component_wrapper__width|default('site'),
+      component_wrapper__alignment: 'center',
+      component_wrapper__heading__level: '2',
       component_wrapper__label: content.field_heading.0 ? content.field_heading : '',
       }%}
-      {% block component_wrapper_inner %}
+      {% block inner %}
         {% if content.field_heading_links.0 %}
           <div class="cta-group">
             {{ content.field_heading_links|children }}


### PR DESCRIPTION
## [1351: Wave 6 — repoint view + resource-view blocks to the component-wrapper SDC](https://github.com/yalesites-org/YaleSites-Internal/issues/1351)

Stacked on `1351-migrate-cl-to-sdc` (the epic) — one of the Wave 6 spin-offs split out by blast radius. This is the lowest-blast one: the deferred consumer-repoint for the already-built, create-only `atomic:component-wrapper` SDC (Wave 5).

### Description of work
Repoints the `view` and `resource-view` Layout Builder block adapters to render through `atomic:component-wrapper` (slot `inner`) instead of embedding the raw `@organisms/component-wrapper/yds-component-wrapper.twig` directly.

`component_wrapper__alignment` (`'center'`) and `component_wrapper__heading__level` (`'2'`) are passed explicitly: the SDC validates props against its schema, whereas the raw embed had relied on the CLT template's internal defaults. The live outer wrapper `<div>` (`data-component-width` / `data-embedded-components` / BEM class), the `field_heading_links` cta-group, and the params field are all preserved.

### Functional testing steps
- [ ] On a page with a generic **View** block and/or a **Resource View** block, confirm it renders identically to production — heading label, view content, and pagination.
- [ ] View Source (twig debug on) shows `Component start: atomic:component-wrapper` around the block (SDC resolution).
- [ ] No `InvalidComponentException` / white screen.

Verified locally: `/generic-homepage` and `/kitchen-sink/kitchen-sink-homepage` render the view blocks through `atomic:component-wrapper` (HTTP 200), with the heading label, view content, and pagination intact.

References yalesites-org/YaleSites-Internal#1351

---
Created with AI
