### PR TITLE
1351: Wave 6 — repoint event-calendar block to component-wrapper SDC

### DIFF
--- a/templates/block/layout-builder/block--inline-block--event-calendar.html.twig
+++ b/templates/block/layout-builder/block--inline-block--event-calendar.html.twig
@@ -19,11 +19,13 @@
   {% endif %}
 
   <div {{ add_attributes(view__attibutes) }}>
-    {% embed "@organisms/component-wrapper/yds-component-wrapper.twig" with {
+    {% embed 'atomic:component-wrapper' with {
       component_wrapper__width: component_wrapper__width|default('site'),
+      component_wrapper__alignment: 'center',
+      component_wrapper__heading__level: '2',
       component_wrapper__label: content.field_heading.0 ? content.field_heading : '',
       }%}
-      {% block component_wrapper_inner %}
+      {% block inner %}
         {% if content.field_heading_links.0 %}
           <div class="cta-group">
             {{ content.field_heading_links|children }}


### PR DESCRIPTION
## [1351: Wave 6 — repoint event-calendar block to the component-wrapper SDC](https://github.com/yalesites-org/YaleSites-Internal/issues/1351)

Stacked on `1351-migrate-cl-to-sdc` (the epic). Completes the component-wrapper consumer repoints alongside `view` + `resource-view` (atomic#486).

### Description of work
Repoints the event-calendar Layout Builder block adapter to render through `atomic:component-wrapper` (slot `inner`) instead of embedding the raw `@organisms/component-wrapper/yds-component-wrapper.twig` directly. Same 3-edit repoint as the `view`/`resource-view` blocks (embed target, block name → `inner`, explicit `component_wrapper__alignment`/`__heading__level` props for the SDC's schema validation).

This was originally flagged as the Wave 6 "hold" item over its AJAX filter form + calendar JS + modal — but those all live **inside** the `field_basic_params` render array (the slot value the block prints). The thin wrapper only wraps; it never touches the form/JS/modal, so no Views-rework or calendar SDC is needed. The live outer wrapper `<div>`, `field_heading_links` cta-group, and `field_basic_params` are preserved.

### Functional testing steps
- [ ] On a page with an **Events Calendar** block (e.g. the event-calendar test page), confirm it renders identically to production.
- [ ] **Smoke-test the AJAX month navigation** (prev/next month swaps the calendar) and the **event modal** (opens correctly) — these are the runtime behaviors to confirm after the DOM is nested one level deeper.
- [ ] View Source shows `Component start: atomic:component-wrapper` around the block; no `InvalidComponentException` / white screen.

Verified locally: `/event-calendar-test` returns 200, resolves through `atomic:component-wrapper`, the calendar + filter-form AJAX wrapper render, no validation error. (Interactive AJAX/modal to smoke-test on the multidev.)

References yalesites-org/YaleSites-Internal#1351

---
Created with AI
