### PR TITLE
1362: Wave 7: Global site chrome

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -8,6 +8,7 @@
 use Drupal\node\Entity\Node;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Url;
 use Drupal\media\MediaInterface;
 
 /**
@@ -66,6 +67,56 @@ function atomic_preprocess_menu(&$variables, $hook) {
       }
     }
   }
+
+  // Provide a flattened, SDC-safe copy of the menu tree (plain arrays, string
+  // URLs) for the navigation Single Directory Components. The render tree holds
+  // \Drupal\Core\Url objects and menu-link entities that cannot cross an SDC
+  // prop boundary; the nav SDCs pass this copy with menu__contextual: true so
+  // the shared CLT menu engine uses the string URL directly.
+  $variables['menu__flattened_items'] = _atomic_flatten_menu_items($variables['items']);
+}
+
+/**
+ * Flattens a Drupal menu tree into a plain, SDC-safe array.
+ *
+ * Preserves only the fields the component-library menu templates consume,
+ * converting each item's Url object to a string and recursing into `below`.
+ * Non-serializable values (menu-link entities, Attribute objects) are dropped.
+ *
+ * @param array $items
+ *   Menu items as prepared for the `menu` theme hook.
+ *
+ * @return array
+ *   The flattened items (string URLs, recursive `below`).
+ */
+function _atomic_flatten_menu_items(array $items): array {
+  $flattened = [];
+  foreach ($items as $item) {
+    $url = $item['url'] ?? '';
+    $flat = [
+      'title' => isset($item['title']) ? (string) $item['title'] : '',
+      'url' => $url instanceof Url ? $url->toString() : (string) $url,
+      'is_active' => !empty($item['is_active']),
+      'below' => !empty($item['below']) ? _atomic_flatten_menu_items($item['below']) : [],
+    ];
+    if (isset($item['is_cas'])) {
+      $flat['is_cas'] = (bool) $item['is_cas'];
+    }
+    if (isset($item['list__item__is_heading'])) {
+      $flat['list__item__is_heading'] = (bool) $item['list__item__is_heading'];
+    }
+    if (isset($item['heading_cta'])) {
+      $flat['heading_cta'] = (string) $item['heading_cta'];
+    }
+    if (isset($item['node_title'])) {
+      $flat['node_title'] = (string) $item['node_title'];
+    }
+    if (!empty($item['list__item__modifiers']) && is_array($item['list__item__modifiers'])) {
+      $flat['list__item__modifiers'] = $item['list__item__modifiers'];
+    }
+    $flattened[] = $flat;
+  }
+  return $flattened;
 }
 
 /**

--- a/atomic.theme
+++ b/atomic.theme
@@ -120,6 +120,18 @@ function _atomic_flatten_menu_items(array $items): array {
 }
 
 /**
+ * Implements hook_preprocess_book_tree().
+ *
+ * Provides a flattened, SDC-safe copy of the book tree for the in-this-section
+ * navigation SDC. The book_tree hook is not covered by atomic_preprocess_menu,
+ * but its items share the menu-item shape (Url objects + recursive `below`), so
+ * the same flattening helper applies.
+ */
+function atomic_preprocess_book_tree(&$variables) {
+  $variables['book__flattened_items'] = _atomic_flatten_menu_items($variables['items'] ?? []);
+}
+
+/**
  * Implements hook_preprocess_pager().
  *
  * Adds total pages to the pager variables.

--- a/atomic.theme
+++ b/atomic.theme
@@ -20,6 +20,16 @@ function atomic_preprocess_region__header(&$variables) {
   $variables['site_name'] = \Drupal::config('system.site')->get('name');
   $variables['header_variant'] = 'normal';
 
+  // Flatten the utility drop-button menu tree to string URLs so it can cross the
+  // site-header SDC prop boundary. The SDC isolates its render context, so the
+  // tree can no longer be pulled in the template with
+  // drupal_menu('utility-drop-button-navigation')['#items'] and passed to the
+  // organism via context inheritance; the flattened copy is rendered with
+  // menu__contextual: true instead (mirrors the nav SDCs).
+  $dropdown = \Drupal::service('twig_tweak.menu_view_builder')
+    ->build('utility-drop-button-navigation');
+  $variables['utility_nav__dropdown__items'] = _atomic_flatten_menu_items($dropdown['#items'] ?? []);
+
   $node = \Drupal::routeMatch()->getParameter('node');
   if ($node instanceof Node && $node->bundle() == 'page') {
     if (_node_is_a_collection($node)) {

--- a/components/breadcrumbs/breadcrumbs.component.yml
+++ b/components/breadcrumbs/breadcrumbs.component.yml
@@ -6,10 +6,12 @@ description: >
   Site breadcrumb trail. Thin SDC wrapper over the component library's
   @organisms/menu/breadcrumbs/yds-breadcrumbs.twig template; the real markup, SCSS,
   and JS stay in component-library-twig. Global chrome (Wave 7 / #1362): this is the
-  component contract. It is NOT yet wired into the live render path — the standalone
-  breadcrumb block is disabled and the live trail is produced by the bespoke
-  title-breadcrumb combo block (ys-title-breadcrumb.html.twig + YaleSitesBreadcrumbsManager).
-  Wiring chrome to SDCs is a pending decision (see the epic decisions log).
+  component contract, and it IS wired into the live render path: the ys_breadcrumb_block
+  theme hook is overridden by atomic/templates/navigation/ys-breadcrumb-block.html.twig,
+  which renders atomic:breadcrumbs. The live trail is produced by the bespoke
+  title-breadcrumb combo (ys-title-breadcrumb.html.twig). Caveat: the Layout Builder
+  preview branch of ys-title-breadcrumb.html.twig still includes the raw CLT template
+  directly, so the SDC covers the front-end path, not the LB preview.
 props:
   type: object
   required:

--- a/components/breadcrumbs/breadcrumbs.twig
+++ b/components/breadcrumbs/breadcrumbs.twig
@@ -7,9 +7,12 @@
  # `items`). `directory` is threaded so the nested icon atoms resolve the SVG
  # sprite path.
  #
- # Contract only: not yet wired into the live render path (the standalone
- # breadcrumb block is disabled; the live trail comes from the bespoke
- # title-breadcrumb combo). See docs/sdc + the epic decisions log.
+ # Wired into the live render path via
+ # atomic/templates/navigation/ys-breadcrumb-block.html.twig (the ys_breadcrumb_block
+ # theme-hook override renders atomic:breadcrumbs). The live trail comes from the bespoke
+ # title-breadcrumb combo. Caveat: the LB-preview branch of ys-title-breadcrumb.html.twig
+ # still includes the raw CLT template, so the SDC covers the front-end path, not the LB
+ # preview.
  #}
 {{ include('@organisms/menu/breadcrumbs/yds-breadcrumbs.twig', {
   breadcrumbs__items: breadcrumbs__items,

--- a/components/in-this-section/in-this-section.component.yml
+++ b/components/in-this-section/in-this-section.component.yml
@@ -1,0 +1,50 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: In This Section
+status: stable
+group: Organisms
+description: >
+  The "in this section" secondary navigation for book/collection pages (global
+  chrome, Wave 7 / #1362). Thin SDC wrapper over
+  @organisms/site-in-this-section/yds-site-in-this-section.twig (which wraps the
+  secondary-nav organism). The book tree carries \Drupal\Core\Url objects that
+  cannot cross the SDC prop boundary, so the render-path adapter
+  (book-tree.html.twig) passes a flattened, string-URL copy of the tree
+  (atomic.theme _atomic_flatten_menu_items(), via atomic_preprocess_book_tree)
+  and this wrapper renders it with menu__contextual: true.
+props:
+  type: object
+  required:
+    - in_this_section__items
+  properties:
+    in_this_section__items:
+      title: Menu items
+      description: >
+        The flattened book/section tree. Each item has a title, a string url, an
+        is_active flag, and a recursive `below`.
+      type: array
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+          url:
+            type:
+              - string
+              - "null"
+          is_active:
+            type: boolean
+          below:
+            type: array
+    site_section_wrap__theme:
+      title: Section navigation theme (dial)
+      description: >
+        Color theme for the section navigation, from the book_navigation theme
+        setting; nullable because getThemeSetting can return NULL.
+      type:
+        - string
+        - "null"
+      default: one
+libraryOverrides:
+  dependencies:
+    - atomic/secondary-nav
+    - atomic/in-this-section

--- a/components/in-this-section/in-this-section.twig
+++ b/components/in-this-section/in-this-section.twig
@@ -1,0 +1,18 @@
+{#
+ # SDC thin wrapper for the "In This Section" secondary navigation (global
+ # chrome, Wave 7 / #1362).
+ #
+ # Delegates to @organisms/site-in-this-section/yds-site-in-this-section.twig,
+ # which wraps the secondary-nav organism (both drive the shared @molecules/menu
+ # engine). Items are passed as the ambient `items` the wrapped secondary-nav
+ # falls back to. menu__contextual: true tells the engine the item urls are
+ # already plain strings (the adapter flattens the book tree via atomic.theme
+ # _atomic_flatten_menu_items()). `directory` is threaded so nested icon atoms
+ # (the expand/collapse chevrons) resolve their sprite path.
+ #}
+{{ include('@organisms/site-in-this-section/yds-site-in-this-section.twig', {
+  items: in_this_section__items,
+  menu__contextual: true,
+  site_section_wrap__theme: site_section_wrap__theme,
+  directory: directory,
+}, with_context = false) }}

--- a/components/primary-nav/primary-nav.component.yml
+++ b/components/primary-nav/primary-nav.component.yml
@@ -1,0 +1,59 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Primary Navigation
+status: stable
+group: Organisms
+description: >
+  The site's primary navigation (global chrome, Wave 7 / #1362). Thin SDC wrapper
+  over @organisms/menu/primary-nav/yds-primary-nav.twig. The Drupal menu render
+  tree carries \Drupal\Core\Url objects that cannot cross the SDC prop boundary,
+  so the render-path adapter (menu--extras--main.html.twig) passes a flattened,
+  string-URL copy of the tree (atomic.theme _atomic_flatten_menu_items()) and this
+  wrapper renders it with menu__contextual: true.
+props:
+  type: object
+  required:
+    - primary_nav__items
+  properties:
+    primary_nav__items:
+      title: Menu items
+      description: >
+        The flattened primary-menu tree. Each item has a title, a string url,
+        an is_active flag, and a recursive `below`; mega-menu items may also
+        carry heading fields.
+      type: array
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+          url:
+            type:
+              - string
+              - "null"
+          is_active:
+            type: boolean
+          is_cas:
+            type: boolean
+          list__item__is_heading:
+            type: boolean
+          heading_cta:
+            type: string
+          node_title:
+            type: string
+          list__item__modifiers:
+            type: array
+          below:
+            type: array
+    menu__variation:
+      title: Menu variation
+      description: >
+        Display style (basic | mega | focus). Sourced from the header_variation
+        theme setting; nullable because getHeaderSetting can return NULL, in which
+        case the CLT template defaults to basic.
+      type:
+        - string
+        - "null"
+      default: basic
+libraryOverrides:
+  dependencies:
+    - atomic/primary-nav

--- a/components/primary-nav/primary-nav.twig
+++ b/components/primary-nav/primary-nav.twig
@@ -1,0 +1,20 @@
+{#
+ # SDC thin wrapper for the Primary Navigation organism (global chrome, Wave 7 / #1362).
+ #
+ # The canonical template + SCSS/JS live in the component library
+ # (@organisms/menu/primary-nav/yds-primary-nav.twig, which drives the shared
+ # @molecules/menu engine). This shim maps SDC props onto the template's variables.
+ #
+ # menu__contextual: true tells the shared menu engine that item urls are already
+ # plain strings (the render-path adapter flattens the Drupal menu tree with
+ # atomic.theme _atomic_flatten_menu_items(), converting Url objects to strings),
+ # so _yds-menu-item.twig skips its ->toString() call. primary_nav__items is passed
+ # positionally (not via ambient `items`) because SDC does not inherit Twig context.
+ # `directory` is threaded so nested icon atoms resolve the SVG sprite path.
+ #}
+{{ include('@organisms/menu/primary-nav/yds-primary-nav.twig', {
+  primary_nav__items: primary_nav__items,
+  menu__variation: menu__variation,
+  menu__contextual: true,
+  directory: directory,
+}, with_context = false) }}

--- a/components/site-footer/site-footer.component.yml
+++ b/components/site-footer/site-footer.component.yml
@@ -1,0 +1,65 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Site Footer
+status: stable
+group: Organisms
+description: >
+  The global site footer (Wave 7 / #1362). Thin SDC wrapper over
+  @organisms/site-footer/yds-site-footer.twig; the real markup and SCSS stay in
+  component-library-twig. The footer is global chrome (rendered from the footer
+  region via the ys_core footer block), not a Layout Builder block, so its
+  render-path adapter is ys_core/templates/ys-footer-block.html.twig.
+props:
+  type: object
+  properties:
+    site_footer__variation:
+      title: Footer variation
+      description: >
+        Layout variation. The ys_core footer block chooses this from the
+        `footer_variation` context value (basic when unset). The organism
+        branches on it, so the value set is closed.
+      type: string
+      enum:
+        - basic
+        - mega
+      default: basic
+    site_footer__theme:
+      title: Footer theme (dial)
+      description: >
+        Footer color theme. Sourced from the atomic theme setting
+        `footer_theme` at render (getThemeSetting), not a Layout Builder block
+        field, so there is no field formatter to derive a closed enum from.
+        Typed as a nullable string because getThemeSetting can return NULL and
+        SDC validates NULL against the declared type; over-strict enums would
+        assertion-fail (white-screen) on every page in dev.
+      type:
+        - string
+        - "null"
+      default: one
+    site_footer__accent:
+      title: Footer accent color (dial)
+      description: >
+        Accent color for footer links/interactive elements. Sourced from the
+        theme setting `footer_accent` (see the theme note on site_footer__theme).
+      type:
+        - string
+        - "null"
+      default: one
+    site_footer__border_thickness:
+      title: Border thickness
+      description: >
+        Decorative top-border thickness (a border.thickness design-token key).
+        Set by the render-path adapter; nullable string for the same reason as
+        the theme dials.
+      type:
+        - string
+        - "null"
+      default: "0"
+slots:
+  footer__content:
+    title: Footer content
+    required: true
+    description: >
+      The rendered footer body (basic or mega layout, logos, link columns,
+      social links, meta). Populated by the ys_core footer block template.
+      Named footer__content (not footer__inner) to avoid colliding with the CLT
+      organism's own footer__inner block, which this wrapper forwards it into.

--- a/components/site-footer/site-footer.twig
+++ b/components/site-footer/site-footer.twig
@@ -1,0 +1,35 @@
+{#
+ # SDC thin wrapper for the Site Footer organism (global chrome, Wave 7 / #1362).
+ #
+ # The canonical template + SCSS live in the component library
+ # (@organisms/site-footer/yds-site-footer.twig). This shim maps SDC props onto
+ # the organism's variables and forwards the footer__content slot into the
+ # organism's footer__inner block.
+ #
+ # Slot forwarding pattern (see docs/sdc/recipe-convert-a-component-to-sdc.md):
+ #  - The slot is named footer__content, distinct from the CLT organism's own
+ #    footer__inner block, to avoid a Twig block-name collision.
+ #  - block('footer__content') captures the override so this works whether the
+ #    component is rendered via the SDC render element (#slots) or a Twig
+ #    {% embed %} block override.
+ #  - The captured value is passed through the (isolated, `only`) embed context
+ #    and printed with |raw because it is already-rendered, trusted output
+ #    (block() returns a plain string).
+ #  - The receiver block is guarded by {% if false %} so it is registered at
+ #    compile time (for block() to find) but does not also render inline.
+ #  - The footer body's own base class (site_footer__base_class) is set by the
+ #    render-path adapter, not here, because the slot renders in the adapter's
+ #    context (the organism sets it internally only for its own wrapper markup).
+ #}
+{% set footer__content_slot = block('footer__content') %}
+{% embed '@organisms/site-footer/yds-site-footer.twig' with {
+  site_footer__variation: site_footer__variation,
+  site_footer__theme: site_footer__theme,
+  site_footer__accent: site_footer__accent,
+  site_footer__border_thickness: site_footer__border_thickness,
+  footer__content_slot: footer__content_slot,
+  directory: directory,
+} only %}
+  {% block footer__inner %}{{ footer__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}{% block footer__content %}{% endblock %}{% endif %}

--- a/components/site-header/site-header.component.yml
+++ b/components/site-header/site-header.component.yml
@@ -1,0 +1,202 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Site Header
+status: stable
+group: Organisms
+description: >
+  The global site header (Wave 7 / #1413, split from #1362). Thin SDC wrapper
+  over @organisms/site-header/yds-site-header.twig; the real markup and SCSS stay
+  in component-library-twig. The header is global chrome (rendered from the header
+  region), not a Layout Builder block, so its render-path adapter is the theme's
+  templates/layout/region--header.html.twig. Because an SDC isolates its render
+  context (unlike the previous non-`only` embed), every value the organism and its
+  nested utility-nav include consumed via context inheritance is threaded here as
+  an explicit prop or slot. The dropdown menu tree is flattened to string URLs in
+  atomic_preprocess_region__header() (via _atomic_flatten_menu_items) so it can
+  cross the prop boundary; the wrapper renders it with menu__contextual: true.
+props:
+  type: object
+  properties:
+    site_header__site_name:
+      title: Site name
+      description: The site name text (system.site name), shown as the branding link.
+      type:
+        - string
+        - "null"
+    site_header__site_link:
+      title: Site link
+      description: URL the site branding links to.
+      type:
+        - string
+        - "null"
+      default: /
+    site_header__collection_nav_name:
+      title: Collection nav name
+      description: >
+        Label for the collection's in-header primary navigation (only set on
+        collection pages whose nav position is "in header").
+      type:
+        - string
+        - "null"
+    site_header__collection_nav_link:
+      title: Collection nav link
+      description: URL for the collection in-header nav branding link.
+      type:
+        - string
+        - "null"
+    site_header__collection_nav_position:
+      title: Collection nav position
+      description: >
+        "in_header" when a collection renders its primary nav inside the header,
+        otherwise empty. Drives the organism's collection branding + data attr.
+      type:
+        - string
+        - "null"
+    site_header__branding_name:
+      title: Site-wide branding name
+      description: University-wide branding name (Yale University) in the secondary bar.
+      type:
+        - string
+        - "null"
+    site_header__branding_link:
+      title: Site-wide branding link
+      description: URL for the university-wide branding link.
+      type:
+        - string
+        - "null"
+    site_header__border_thickness:
+      title: Border thickness
+      description: >
+        Decorative navigation border thickness (a border.thickness token key). Set
+        by the render-path adapter; nullable string like the other header dials.
+      type:
+        - string
+        - "null"
+      default: "8"
+    site_header__theme:
+      title: Header theme (dial)
+      description: >
+        Header color theme. Sourced from the atomic theme setting `header_theme`
+        at render (getThemeSetting), which can return NULL, so it is typed as a
+        nullable string; an over-strict enum would assertion-fail (white-screen)
+        on every page in dev.
+      type:
+        - string
+        - "null"
+      default: one
+    site_header__accent:
+      title: Header accent color (dial)
+      description: >
+        Accent color for header links/interactive elements. Sourced from the theme
+        setting `header_accent` (see the note on site_header__theme).
+      type:
+        - string
+        - "null"
+      default: one
+    site_header__menu__variation:
+      title: Menu variation
+      description: >
+        Display style (basic | mega | focus). Sourced from the header_variation
+        setting; nullable because getHeaderSetting can return NULL, in which case
+        the CLT template defaults to basic.
+      type:
+        - string
+        - "null"
+      default: basic
+    site_header__nav_position:
+      title: Navigation position
+      description: Horizontal alignment of the primary navigation (left | center | right).
+      type:
+        - string
+        - "null"
+      default: left
+    utility_nav__search:
+      title: Utility search enabled
+      description: >
+        Whether the utility search form renders. Sourced from the
+        search.enable_search_form header setting (an integer 0/1), so typed as a
+        nullable boolean-or-integer.
+      type:
+        - boolean
+        - integer
+        - "null"
+    utility_nav__link__content:
+      title: Utility CTA content
+      description: Label for the optional utility-bar call-to-action link (cta_content).
+      type:
+        - string
+        - "null"
+    utility_nav__link__url:
+      title: Utility CTA url
+      description: URL for the optional utility-bar call-to-action link (cta_url).
+      type:
+        - string
+        - "null"
+    utility_nav__dropdown_link__content:
+      title: Utility dropdown button title
+      description: >
+        Label for the utility dropdown button (the dropdown_button_title setting);
+        empty/NULL disables the dropdown.
+      type:
+        - string
+        - "null"
+    utility_nav__dropdown_link__url:
+      title: Utility dropdown button url
+      description: URL for the dropdown button control ('#'; the menu opens in place).
+      type:
+        - string
+        - "null"
+    utility_nav__dropdown__items:
+      title: Utility dropdown items
+      description: >
+        The flattened utility-drop-button-navigation menu tree. Each item has a
+        title, a string url, an is_active flag, an optional is_cas flag, and a
+        recursive `below`. Flattened in atomic_preprocess_region__header so the
+        Url objects do not cross the SDC prop boundary.
+      type: array
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+          url:
+            type:
+              - string
+              - "null"
+          is_active:
+            type: boolean
+          is_cas:
+            type: boolean
+          list__item__is_heading:
+            type: boolean
+          heading_cta:
+            type: string
+          node_title:
+            type: string
+          list__item__modifiers:
+            type: array
+          below:
+            type: array
+slots:
+  primary_nav__content:
+    title: Primary navigation
+    required: true
+    description: >
+      The rendered primary navigation (the main_navigation block, or a collection's
+      in-header nav). Forwarded into the organism's site_header__primary_nav block.
+  background_image__content:
+    title: Background image
+    description: >
+      The rendered focus-header background image (responsive image), front page
+      only. Forwarded into the organism's site_header__background_image block; its
+      presence also toggles the organism's with-background-image data attribute.
+  utility_nav__content:
+    title: Utility navigation
+    description: >
+      The rendered utility_navigation block. Provided to the organism as
+      drupal_utility_nav so the CLT utility-nav template prefers it over its own
+      menu include.
+  site_name_image__content:
+    title: Site name image
+    description: >
+      An SVG site-name image (from the site_name_image setting) rendered in place
+      of the text site name. Provided to the organism as site_header__site_name_image.

--- a/components/site-header/site-header.twig
+++ b/components/site-header/site-header.twig
@@ -1,0 +1,69 @@
+{#
+ # SDC thin wrapper for the Site Header organism (global chrome, Wave 7 / #1413,
+ # split from #1362).
+ #
+ # The canonical template + SCSS live in the component library
+ # (@organisms/site-header/yds-site-header.twig). This shim maps SDC props onto the
+ # organism's variables and forwards four markup-captured slots.
+ #
+ # Why so many props: the previous region--header.html.twig embedded the organism
+ # WITHOUT `only`, so region-scope values (utility search flag, CTA links, dropdown
+ # links/items, site-name image, background image) reached the organism's nested
+ # utility-nav include via Twig context inheritance. An SDC isolates context, so
+ # each is threaded explicitly here.
+ #
+ # Slot forwarding pattern (see the site-footer wrapper / docs/sdc): each slot is
+ # captured with block() so it works whether rendered via the SDC render element
+ # (#slots) or a Twig {% embed %} block override; the slot names are distinct from
+ # the organism's own block names to avoid a Twig block-name collision; the receiver
+ # blocks are guarded by {% if false %} so they register at compile time (for block()
+ # to find) without rendering inline. Captured values are printed |raw because they
+ # are already-rendered, trusted output.
+ #
+ # menu__contextual: true tells the shared CLT menu engine the dropdown item urls
+ # are already plain strings (flattened in atomic_preprocess_region__header), so
+ # _yds-menu-item.twig skips its ->toString() call. It only affects the dropdown:
+ # the primary/utility nav arrive as already-rendered slots, captured in the
+ # adapter's context, insulated from this flag.
+ #}
+{% set primary_nav__content_slot %}{{ block('primary_nav__content')|raw }}{% endset %}
+{% set background_image__content_slot %}{{ block('background_image__content')|raw }}{% endset %}
+{% set utility_nav__content_slot %}{{ block('utility_nav__content')|raw }}{% endset %}
+{% set site_name_image__content_slot %}{{ block('site_name_image__content')|raw }}{% endset %}
+
+{% embed '@organisms/site-header/yds-site-header.twig' with {
+  site_header__site_name: site_header__site_name,
+  site_header__site_link: site_header__site_link,
+  site_header__collection_nav_name: site_header__collection_nav_name,
+  site_header__collection_nav_link: site_header__collection_nav_link,
+  site_header__collection_nav_position: site_header__collection_nav_position,
+  site_header__branding_name: site_header__branding_name,
+  site_header__branding_link: site_header__branding_link,
+  site_header__border_thickness: site_header__border_thickness,
+  site_header__theme: site_header__theme,
+  site_header__accent: site_header__accent,
+  site_header__menu__variation: site_header__menu__variation,
+  site_header__nav_position: site_header__nav_position,
+  site_header__site_name_image: site_name_image__content_slot,
+  site_header__background_image: background_image__content_slot,
+  drupal_utility_nav: utility_nav__content_slot,
+  utility_nav__search: utility_nav__search,
+  utility_nav__link__content: utility_nav__link__content,
+  utility_nav__link__url: utility_nav__link__url,
+  utility_nav__dropdown_link__content: utility_nav__dropdown_link__content,
+  utility_nav__dropdown_link__url: utility_nav__dropdown_link__url,
+  utility_nav__dropdown__items: utility_nav__dropdown__items,
+  menu__contextual: true,
+  directory: directory,
+  primary_nav__content_slot: primary_nav__content_slot,
+  background_image__content_slot: background_image__content_slot,
+} only %}
+  {% block site_header__primary_nav %}{{ primary_nav__content_slot|raw }}{% endblock %}
+  {% block site_header__background_image %}{{ background_image__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}
+  {% block primary_nav__content %}{% endblock %}
+  {% block background_image__content %}{% endblock %}
+  {% block utility_nav__content %}{% endblock %}
+  {% block site_name_image__content %}{% endblock %}
+{% endif %}

--- a/components/utility-nav/utility-nav.component.yml
+++ b/components/utility-nav/utility-nav.component.yml
@@ -1,0 +1,41 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Utility Navigation
+status: stable
+group: Organisms
+description: >
+  The utility navigation menu (global chrome, Wave 7 / #1362). Thin SDC wrapper
+  over @organisms/menu/utility-nav/_utility-nav--menu.twig, i.e. the utility
+  menu rendered by the utility_navigation block. Like primary-nav, the Drupal
+  menu tree carries \Drupal\Core\Url objects that cannot cross the SDC prop
+  boundary, so the render-path adapter (menu--extras--utility-navigation.html.twig)
+  passes a flattened, string-URL copy of the tree (atomic.theme
+  _atomic_flatten_menu_items()) and this wrapper renders it with
+  menu__contextual: true. CSS loads from the global stylesheet, so no
+  libraryOverrides are needed.
+props:
+  type: object
+  required:
+    - utility_nav__items
+  properties:
+    utility_nav__items:
+      title: Menu items
+      description: >
+        The flattened utility-menu tree. Each item has a title, a string url, an
+        is_active flag, an optional is_cas flag (set by ys_node_access for CAS
+        links), and a recursive `below`.
+      type: array
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+          url:
+            type:
+              - string
+              - "null"
+          is_active:
+            type: boolean
+          is_cas:
+            type: boolean
+          below:
+            type: array

--- a/components/utility-nav/utility-nav.twig
+++ b/components/utility-nav/utility-nav.twig
@@ -1,0 +1,14 @@
+{#
+ # SDC thin wrapper for the Utility Navigation menu (global chrome, Wave 7 / #1362).
+ #
+ # Delegates to @organisms/menu/utility-nav/_utility-nav--menu.twig (which drives
+ # the shared @molecules/menu engine). menu__contextual: true tells the engine the
+ # item urls are already plain strings (the adapter flattens the Drupal menu tree
+ # via atomic.theme _atomic_flatten_menu_items()), so _yds-menu-item.twig skips its
+ # ->toString() call. `directory` is threaded so nested atoms resolve asset paths.
+ #}
+{{ include('@organisms/menu/utility-nav/_utility-nav--menu.twig', {
+  utility_nav__items: utility_nav__items,
+  menu__contextual: true,
+  directory: directory,
+}, with_context = false) }}

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -43,11 +43,12 @@
     {% set secondary_nav_present = secondary_nav_present |default(FALSE) %}
 
     {% if secondary_nav_present %}
-      {% include "@molecules/link-skip/yds-link-skip.twig" with {
-        link_skip__content: 'Skip to secondary menu'|t ,
+      {% embed "atomic:link-skip" with {
         link_skip__url: '#block-atomic-custombooknavigation',
         link_skip__extra_class: 'visually-hidden focusable',
-      }%}
+      } %}
+        {% block link_skip__content_slot %}{{ 'Skip to secondary menu'|t }}{% endblock %}
+      {% endembed %}
     {% endif %}
 
     {#
@@ -62,11 +63,12 @@
         components/_settings/config.css (for link jupming adjustments)
         templates/navigation/book-tree.html.twig (for the secondary nav bypass div)
     #}
-    {% include "@molecules/link-skip/yds-link-skip.twig" with {
-      link_skip__content: 'Skip to main content'|t ,
+    {% embed "atomic:link-skip" with {
       link_skip__url: main_content_id,
       link_skip__extra_class: 'visually-hidden focusable',
-    }%}
+    } %}
+      {% block link_skip__content_slot %}{{ 'Skip to main content'|t }}{% endblock %}
+    {% endembed %}
 
     {{ page_top }}
     {{ page }}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -1,25 +1,24 @@
 {#
-  # Available Variables
+  # Render-path adapter for the site header SDC (atomic:site-header, Wave 7 / #1413).
+  #
+  # Available Variables (from atomic_preprocess_region__header + ys_core_preprocess_region)
   # - site_name
-  # - collection_nav_name
-  # - collection_nav_link
-  # - collection_nav_menu_items
-
-  # - header_variant
+  # - header_variant ('normal' | 'in_header')
+  # - collection_nav_name, collection_nav_link, collection_nav_menu_items (in_header only)
+  # - utility_nav__dropdown__items (flattened dropdown menu tree)
+  # - utility_nav__search, utility_nav__link__content, utility_nav__link__url
+  # - site_header__background_image (focus header responsive image, front page only)
   #
   # @see atomic_preprocess_region__header()
+  # @see ys_core_preprocess_region()
 #}
 
 {{ elements.alert_block }}
 
-{% if getHeaderSetting('site_name_image') %}
-  {% set isSiteHeaderLogo = TRUE %}
-  {% set site_header__site_name_image = getHeaderSetting('site_name_image') %}
-{% endif %}
-
-{# Dropdown button links in utility navigation #}
+{# Dropdown button links in utility navigation. #}
 {% set utility_nav_button_title = getHeaderSetting('dropdown_button_title') %}
-{% set utility_nav__dropdown__items = drupal_menu('utility-drop-button-navigation')['#items'] %}
+{% set utility_nav__dropdown_link__content = null %}
+{% set utility_nav__dropdown_link__url = null %}
 {% if utility_nav_button_title and utility_nav__dropdown__items %}
   {{ attach_library('atomic/utility-nav-dropdown-menu') }}
   {% set utility_nav__dropdown_link__content = utility_nav_button_title %}
@@ -27,19 +26,13 @@
 {% endif %}
 
 {#
-  Collection primary nav headers use the same header theme as configured in
-  theme settings. The header_theme setting applies consistently across all
-  pages, including those using collection primary navigation.
-#}
-
-{#
   The header config map has 2 values "normal" and "in_header".
 
   normal - Used for most pages, including regular collection pages.
   in_header - Used only for collections with primary navigation.
 
-  This config allows us to use a single "yds-site-header" template and reassign
-  keys on the left, to different values based on the header_variant.
+  Collection primary nav headers use the same header theme as configured in theme
+  settings, so header_theme applies consistently across all pages.
 #}
 {% set header_config_map = {
   'normal': {
@@ -53,28 +46,31 @@
     'collection_nav_position': 'in_header',
   }
 } %}
-
-{# Use header_header_variant to get correct config_map. #}
 {% set header_config = header_config_map[header_variant] %}
 
-{% embed "@organisms/site-header/yds-site-header.twig" with {
+{% set is_focus_header = getHeaderSetting('header_variation') == 'focus' %}
+
+{% embed 'atomic:site-header' with {
   site_header__site_name: site_name,
   site_header__site_link: '/',
   site_header__collection_nav_name: header_config['collection_nav_name'],
   site_header__collection_nav_link: header_config['collection_nav_link'],
+  site_header__collection_nav_position: header_config['collection_nav_position'],
   site_header__branding_name: getHeaderSetting('site_wide_branding_name'),
   site_header__branding_link: getHeaderSetting('site_wide_branding_link'),
-
-  site_header__collection_nav_position: header_config['collection_nav_position'],
-
   site_header__border_thickness: '8',
   site_header__theme: header_config['header_theme'],
   site_header__accent: getThemeSetting('header_accent'),
   site_header__menu__variation: getHeaderSetting('header_variation'),
   site_header__nav_position: getHeaderSetting('nav_position'),
-  drupal_utility_nav: elements.utility_navigation,
+  utility_nav__search: utility_nav__search|default(null),
+  utility_nav__link__content: utility_nav__link__content|default(null),
+  utility_nav__link__url: utility_nav__link__url|default(null),
+  utility_nav__dropdown_link__content: utility_nav__dropdown_link__content,
+  utility_nav__dropdown_link__url: utility_nav__dropdown_link__url,
+  utility_nav__dropdown__items: utility_nav__dropdown__items|default([]),
 } %}
-  {% block site_header__primary_nav %}
+  {% block primary_nav__content %}
     {% if header_variant == 'in_header' %}
       {% include "@organisms/menu/primary-nav/yds-primary-nav.twig" with {
         primary_nav__items: collection_nav_menu_items,
@@ -85,9 +81,15 @@
     {% endif %}
   {% endblock %}
 
-  {% block site_header__background_image %}
-    {% if site_header__background_image %}
-      {{ site_header__background_image }}
-    {% endif %}
-  {% endblock %}
+  {#
+    background_image__content and site_name_image__content are captured by the SDC
+    and used as truthiness flags in the organism (they toggle the with-background-image
+    and site-name-is-image data attributes), so they must render truly EMPTY when
+    absent — hence whitespace-tight blocks, no surrounding newlines.
+  #}
+  {% block background_image__content %}{% if is_focus_header and site_header__background_image %}{{ site_header__background_image }}{% endif %}{% endblock %}
+
+  {% block utility_nav__content %}{{ elements.utility_navigation }}{% endblock %}
+
+  {% block site_name_image__content %}{% if getHeaderSetting('site_name_image') %}{{ getHeaderSetting('site_name_image')|raw }}{% endif %}{% endblock %}
 {% endembed %}

--- a/templates/navigation/book-tree.html.twig
+++ b/templates/navigation/book-tree.html.twig
@@ -10,11 +10,13 @@
 {{ attach_library('atomic/secondary-nav') }}
 {{ attach_library('atomic/in-this-section') }}
 
-{% set secondary_nav__base_class = 'secondary-nav' %}
 {% set html__menu_bypass_id = html__menu_bypass_id|default('main-content-after-secondary-nav') %}
 
-{# Menu #}
-{% include "@organisms/site-in-this-section/yds-site-in-this-section.twig" with {
-  site_section_wrap__theme: getThemeSetting('book_navigation')
-} %}
+{# Menu — rendered through the SDC. Included WITH context so `directory` flows for
+   nested icon atoms; items are the flattened, string-URL copy of the book tree
+   (see atomic_preprocess_book_tree). #}
+{{ include('atomic:in-this-section', {
+  in_this_section__items: book__flattened_items,
+  site_section_wrap__theme: getThemeSetting('book_navigation'),
+}) }}
 <div id="{{ html__menu_bypass_id }}" class="visually-hidden"></div>

--- a/templates/navigation/menu--extras--main.html.twig
+++ b/templates/navigation/menu--extras--main.html.twig
@@ -1,6 +1,9 @@
 {# Note: After enabling menu_item_extras module, this file was renamed from menu--main.html.twig #}
 {{ attach_library('atomic/primary-nav') }}
 
-{% include "@organisms/menu/primary-nav/yds-primary-nav.twig"  with {
+{# Included WITH context (no with_context=false) so `directory` flows into the SDC
+   and nested icon atoms resolve the versioned sprite path (getAssetPath). #}
+{{ include('atomic:primary-nav', {
+  primary_nav__items: menu__flattened_items,
   menu__variation: getHeaderSetting('header_variation'),
-}%}
+}) }}

--- a/templates/navigation/menu--extras--utility-navigation.html.twig
+++ b/templates/navigation/menu--extras--utility-navigation.html.twig
@@ -4,4 +4,8 @@ CAS menu items: There needs to be at least one field inside the menu for this
 template to work. We need this template to work with the ys_node_access module
 to set the is_cas attribute on menu items.
 #}
-{% include "@organisms/menu/utility-nav/_utility-nav--menu.twig" %}
+{# Included WITH context so `directory` and the ys_node_access is_cas flags flow
+   into the SDC. Items are the flattened, string-URL copy of the menu tree. #}
+{{ include('atomic:utility-nav', {
+  utility_nav__items: menu__flattened_items,
+}) }}

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -615,4 +615,24 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('utility-nav', []));
   }
 
+  /**
+   * In This Section (Wave 7, global chrome): a valid item tree passes; the
+   * required items array is enforced.
+   */
+  public function testInThisSectionValid(): void {
+    $this->assertSame([], $this->validate('in-this-section', [
+      'in_this_section__items' => [
+        ['title' => 'Section Home', 'url' => '/section', 'is_active' => TRUE],
+        [
+          'title' => 'Child',
+          'url' => '/section/a',
+          'below' => [['title' => 'Grandchild', 'url' => '/section/a/g']],
+        ],
+      ],
+      'site_section_wrap__theme' => 'one',
+    ]));
+    // Omitting the required in_this_section__items fails.
+    $this->assertNotEmpty($this->validate('in-this-section', ['site_section_wrap__theme' => 'one']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -600,4 +600,19 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('primary-nav', ['menu__variation' => 'basic']));
   }
 
+  /**
+   * Utility Navigation (Wave 7, global chrome): a valid item tree passes; the
+   * required items array is enforced.
+   */
+  public function testUtilityNavValid(): void {
+    $this->assertSame([], $this->validate('utility-nav', [
+      'utility_nav__items' => [
+        ['title' => 'Give', 'url' => '/give'],
+        ['title' => 'Log in', 'url' => '/caslogin', 'is_cas' => TRUE],
+      ],
+    ]));
+    // Omitting the required utility_nav__items fails.
+    $this->assertNotEmpty($this->validate('utility-nav', []));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -559,4 +559,45 @@ class SdcSchemaValidationTest extends UnitTestCase {
     ]));
   }
 
+  /**
+   * Site Footer (Wave 7, global chrome): valid props pass; a bad variation fails.
+   */
+  public function testSiteFooterValid(): void {
+    $this->assertSame([], $this->validate('site-footer', [
+      'site_footer__variation' => 'mega',
+      'site_footer__theme' => 'two',
+      'site_footer__accent' => 'three',
+      'site_footer__border_thickness' => '8',
+    ]));
+    // The theme dials are nullable (getThemeSetting can return NULL).
+    $this->assertSame([], $this->validate('site-footer', ['site_footer__theme' => NULL]));
+    // An out-of-enum variation fails.
+    $this->assertNotEmpty($this->validate('site-footer', ['site_footer__variation' => 'jumbo']));
+  }
+
+  /**
+   * Primary Navigation (Wave 7, global chrome): a valid item tree passes; the
+   * required items array is enforced.
+   */
+  public function testPrimaryNavValid(): void {
+    $this->assertSame([], $this->validate('primary-nav', [
+      'primary_nav__items' => [
+        ['title' => 'Home', 'url' => '/', 'is_active' => TRUE],
+        [
+          'title' => 'About',
+          'url' => '/about',
+          'below' => [['title' => 'Team', 'url' => '/about/team']],
+        ],
+      ],
+      'menu__variation' => 'mega',
+    ]));
+    // menu__variation is nullable (getHeaderSetting can return NULL).
+    $this->assertSame([], $this->validate('primary-nav', [
+      'primary_nav__items' => [['title' => 'Home', 'url' => '/']],
+      'menu__variation' => NULL,
+    ]));
+    // Omitting the required primary_nav__items fails.
+    $this->assertNotEmpty($this->validate('primary-nav', ['menu__variation' => 'basic']));
+  }
+
 }

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -635,4 +635,43 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('in-this-section', ['site_section_wrap__theme' => 'one']));
   }
 
+  /**
+   * Site header: the global chrome header (Wave 7 / #1413).
+   */
+  public function testSiteHeaderValid(): void {
+    $this->assertSame([], $this->validate('site-header', [
+      'site_header__site_name' => 'Yale University',
+      'site_header__site_link' => '/',
+      'site_header__branding_name' => 'Yale University',
+      'site_header__branding_link' => 'https://www.yale.edu',
+      'site_header__border_thickness' => '8',
+      'site_header__theme' => 'three',
+      'site_header__accent' => 'one',
+      'site_header__menu__variation' => 'mega',
+      'site_header__nav_position' => 'left',
+      'utility_nav__search' => 1,
+      'utility_nav__dropdown_link__content' => 'Quick Links',
+      'utility_nav__dropdown_link__url' => '#',
+      'utility_nav__dropdown__items' => [
+        ['title' => 'Faculty', 'url' => '/about-us', 'is_active' => FALSE],
+        [
+          'title' => 'Students',
+          'url' => '/posts',
+          'below' => [['title' => 'News', 'url' => '/posts']],
+        ],
+      ],
+    ]));
+    // The dials are nullable (getThemeSetting/getHeaderSetting can return
+    // NULL); the header must not white-screen when they do.
+    $this->assertSame([], $this->validate('site-header', [
+      'site_header__theme' => NULL,
+      'site_header__menu__variation' => NULL,
+      'utility_nav__search' => NULL,
+    ]));
+    // A wrong-typed search flag (neither bool/int nor null) fails predictably.
+    $this->assertNotEmpty($this->validate('site-header', [
+      'utility_nav__search' => ['unexpected'],
+    ]));
+  }
+
 }


### PR DESCRIPTION
## [1362: Wave 7: Global site chrome](https://github.com/yalesites-org/YaleSites-Internal/issues/1362)

> Footer, skip-link, breadcrumbs, and all three navigations are done and verified. The **site header was split into yalesites-org/YaleSites-Internal#1413** and is **not** part of this PR.

### Description of work
The atomic-theme half of the Wave 7 chrome-to-SDC conversion (full description and testing steps on the yalesites-project PR). Stacked on `1351-migrate-cl-to-sdc`.
- New SDC thin-wrappers: `components/site-footer`, `components/primary-nav`, `components/utility-nav`, `components/in-this-section`.
- `atomic.theme`: `_atomic_flatten_menu_items()` plus `atomic_preprocess_menu` and a new `atomic_preprocess_book_tree` flatten the Drupal menu tree (Url objects) to a plain, string-URL copy the nav SDCs render with `menu__contextual: true`.
- Render-path adapters repointed: `html.html.twig` (skip-link), `templates/navigation/menu--extras--main.html.twig` (primary-nav), `menu--extras--utility-navigation.html.twig` (utility-nav), `book-tree.html.twig` (in-this-section).
- Corrected the stale breadcrumbs SDC docstrings.
- Schema tests: `composer test:sdc` 47 to 51.
- The **site header** is tracked separately in yalesites-org/YaleSites-Internal#1413 and is **not** part of this PR.
- Other work completed in: yalesites-org/yalesites-project#1370

### Functional testing steps:
- [ ] See the functional testing steps on yalesites-org/yalesites-project#1370 (this is the companion theme PR; test via the multidev built from that branch).
- [ ] `lando composer test:sdc` is green (51).

References yalesites-org/YaleSites-Internal#1362
