### PR TITLE
1413: Wave 7: Site header SDC conversion

### DIFF
--- a/atomic.theme
+++ b/atomic.theme
@@ -20,6 +20,16 @@ function atomic_preprocess_region__header(&$variables) {
   $variables['site_name'] = \Drupal::config('system.site')->get('name');
   $variables['header_variant'] = 'normal';
 
+  // Flatten the utility drop-button menu tree to string URLs so it can cross the
+  // site-header SDC prop boundary. The SDC isolates its render context, so the
+  // tree can no longer be pulled in the template with
+  // drupal_menu('utility-drop-button-navigation')['#items'] and passed to the
+  // organism via context inheritance; the flattened copy is rendered with
+  // menu__contextual: true instead (mirrors the nav SDCs).
+  $dropdown = \Drupal::service('twig_tweak.menu_view_builder')
+    ->build('utility-drop-button-navigation');
+  $variables['utility_nav__dropdown__items'] = _atomic_flatten_menu_items($dropdown['#items'] ?? []);
+
   $node = \Drupal::routeMatch()->getParameter('node');
   if ($node instanceof Node && $node->bundle() == 'page') {
     if (_node_is_a_collection($node)) {

--- a/components/site-header/site-header.component.yml
+++ b/components/site-header/site-header.component.yml
@@ -1,0 +1,202 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: Site Header
+status: stable
+group: Organisms
+description: >
+  The global site header (Wave 7 / #1413, split from #1362). Thin SDC wrapper
+  over @organisms/site-header/yds-site-header.twig; the real markup and SCSS stay
+  in component-library-twig. The header is global chrome (rendered from the header
+  region), not a Layout Builder block, so its render-path adapter is the theme's
+  templates/layout/region--header.html.twig. Because an SDC isolates its render
+  context (unlike the previous non-`only` embed), every value the organism and its
+  nested utility-nav include consumed via context inheritance is threaded here as
+  an explicit prop or slot. The dropdown menu tree is flattened to string URLs in
+  atomic_preprocess_region__header() (via _atomic_flatten_menu_items) so it can
+  cross the prop boundary; the wrapper renders it with menu__contextual: true.
+props:
+  type: object
+  properties:
+    site_header__site_name:
+      title: Site name
+      description: The site name text (system.site name), shown as the branding link.
+      type:
+        - string
+        - "null"
+    site_header__site_link:
+      title: Site link
+      description: URL the site branding links to.
+      type:
+        - string
+        - "null"
+      default: /
+    site_header__collection_nav_name:
+      title: Collection nav name
+      description: >
+        Label for the collection's in-header primary navigation (only set on
+        collection pages whose nav position is "in header").
+      type:
+        - string
+        - "null"
+    site_header__collection_nav_link:
+      title: Collection nav link
+      description: URL for the collection in-header nav branding link.
+      type:
+        - string
+        - "null"
+    site_header__collection_nav_position:
+      title: Collection nav position
+      description: >
+        "in_header" when a collection renders its primary nav inside the header,
+        otherwise empty. Drives the organism's collection branding + data attr.
+      type:
+        - string
+        - "null"
+    site_header__branding_name:
+      title: Site-wide branding name
+      description: University-wide branding name (Yale University) in the secondary bar.
+      type:
+        - string
+        - "null"
+    site_header__branding_link:
+      title: Site-wide branding link
+      description: URL for the university-wide branding link.
+      type:
+        - string
+        - "null"
+    site_header__border_thickness:
+      title: Border thickness
+      description: >
+        Decorative navigation border thickness (a border.thickness token key). Set
+        by the render-path adapter; nullable string like the other header dials.
+      type:
+        - string
+        - "null"
+      default: "8"
+    site_header__theme:
+      title: Header theme (dial)
+      description: >
+        Header color theme. Sourced from the atomic theme setting `header_theme`
+        at render (getThemeSetting), which can return NULL, so it is typed as a
+        nullable string; an over-strict enum would assertion-fail (white-screen)
+        on every page in dev.
+      type:
+        - string
+        - "null"
+      default: one
+    site_header__accent:
+      title: Header accent color (dial)
+      description: >
+        Accent color for header links/interactive elements. Sourced from the theme
+        setting `header_accent` (see the note on site_header__theme).
+      type:
+        - string
+        - "null"
+      default: one
+    site_header__menu__variation:
+      title: Menu variation
+      description: >
+        Display style (basic | mega | focus). Sourced from the header_variation
+        setting; nullable because getHeaderSetting can return NULL, in which case
+        the CLT template defaults to basic.
+      type:
+        - string
+        - "null"
+      default: basic
+    site_header__nav_position:
+      title: Navigation position
+      description: Horizontal alignment of the primary navigation (left | center | right).
+      type:
+        - string
+        - "null"
+      default: left
+    utility_nav__search:
+      title: Utility search enabled
+      description: >
+        Whether the utility search form renders. Sourced from the
+        search.enable_search_form header setting (an integer 0/1), so typed as a
+        nullable boolean-or-integer.
+      type:
+        - boolean
+        - integer
+        - "null"
+    utility_nav__link__content:
+      title: Utility CTA content
+      description: Label for the optional utility-bar call-to-action link (cta_content).
+      type:
+        - string
+        - "null"
+    utility_nav__link__url:
+      title: Utility CTA url
+      description: URL for the optional utility-bar call-to-action link (cta_url).
+      type:
+        - string
+        - "null"
+    utility_nav__dropdown_link__content:
+      title: Utility dropdown button title
+      description: >
+        Label for the utility dropdown button (the dropdown_button_title setting);
+        empty/NULL disables the dropdown.
+      type:
+        - string
+        - "null"
+    utility_nav__dropdown_link__url:
+      title: Utility dropdown button url
+      description: URL for the dropdown button control ('#'; the menu opens in place).
+      type:
+        - string
+        - "null"
+    utility_nav__dropdown__items:
+      title: Utility dropdown items
+      description: >
+        The flattened utility-drop-button-navigation menu tree. Each item has a
+        title, a string url, an is_active flag, an optional is_cas flag, and a
+        recursive `below`. Flattened in atomic_preprocess_region__header so the
+        Url objects do not cross the SDC prop boundary.
+      type: array
+      items:
+        type: object
+        properties:
+          title:
+            type: string
+          url:
+            type:
+              - string
+              - "null"
+          is_active:
+            type: boolean
+          is_cas:
+            type: boolean
+          list__item__is_heading:
+            type: boolean
+          heading_cta:
+            type: string
+          node_title:
+            type: string
+          list__item__modifiers:
+            type: array
+          below:
+            type: array
+slots:
+  primary_nav__content:
+    title: Primary navigation
+    required: true
+    description: >
+      The rendered primary navigation (the main_navigation block, or a collection's
+      in-header nav). Forwarded into the organism's site_header__primary_nav block.
+  background_image__content:
+    title: Background image
+    description: >
+      The rendered focus-header background image (responsive image), front page
+      only. Forwarded into the organism's site_header__background_image block; its
+      presence also toggles the organism's with-background-image data attribute.
+  utility_nav__content:
+    title: Utility navigation
+    description: >
+      The rendered utility_navigation block. Provided to the organism as
+      drupal_utility_nav so the CLT utility-nav template prefers it over its own
+      menu include.
+  site_name_image__content:
+    title: Site name image
+    description: >
+      An SVG site-name image (from the site_name_image setting) rendered in place
+      of the text site name. Provided to the organism as site_header__site_name_image.

--- a/components/site-header/site-header.twig
+++ b/components/site-header/site-header.twig
@@ -1,0 +1,69 @@
+{#
+ # SDC thin wrapper for the Site Header organism (global chrome, Wave 7 / #1413,
+ # split from #1362).
+ #
+ # The canonical template + SCSS live in the component library
+ # (@organisms/site-header/yds-site-header.twig). This shim maps SDC props onto the
+ # organism's variables and forwards four markup-captured slots.
+ #
+ # Why so many props: the previous region--header.html.twig embedded the organism
+ # WITHOUT `only`, so region-scope values (utility search flag, CTA links, dropdown
+ # links/items, site-name image, background image) reached the organism's nested
+ # utility-nav include via Twig context inheritance. An SDC isolates context, so
+ # each is threaded explicitly here.
+ #
+ # Slot forwarding pattern (see the site-footer wrapper / docs/sdc): each slot is
+ # captured with block() so it works whether rendered via the SDC render element
+ # (#slots) or a Twig {% embed %} block override; the slot names are distinct from
+ # the organism's own block names to avoid a Twig block-name collision; the receiver
+ # blocks are guarded by {% if false %} so they register at compile time (for block()
+ # to find) without rendering inline. Captured values are printed |raw because they
+ # are already-rendered, trusted output.
+ #
+ # menu__contextual: true tells the shared CLT menu engine the dropdown item urls
+ # are already plain strings (flattened in atomic_preprocess_region__header), so
+ # _yds-menu-item.twig skips its ->toString() call. It only affects the dropdown:
+ # the primary/utility nav arrive as already-rendered slots, captured in the
+ # adapter's context, insulated from this flag.
+ #}
+{% set primary_nav__content_slot %}{{ block('primary_nav__content')|raw }}{% endset %}
+{% set background_image__content_slot %}{{ block('background_image__content')|raw }}{% endset %}
+{% set utility_nav__content_slot %}{{ block('utility_nav__content')|raw }}{% endset %}
+{% set site_name_image__content_slot %}{{ block('site_name_image__content')|raw }}{% endset %}
+
+{% embed '@organisms/site-header/yds-site-header.twig' with {
+  site_header__site_name: site_header__site_name,
+  site_header__site_link: site_header__site_link,
+  site_header__collection_nav_name: site_header__collection_nav_name,
+  site_header__collection_nav_link: site_header__collection_nav_link,
+  site_header__collection_nav_position: site_header__collection_nav_position,
+  site_header__branding_name: site_header__branding_name,
+  site_header__branding_link: site_header__branding_link,
+  site_header__border_thickness: site_header__border_thickness,
+  site_header__theme: site_header__theme,
+  site_header__accent: site_header__accent,
+  site_header__menu__variation: site_header__menu__variation,
+  site_header__nav_position: site_header__nav_position,
+  site_header__site_name_image: site_name_image__content_slot,
+  site_header__background_image: background_image__content_slot,
+  drupal_utility_nav: utility_nav__content_slot,
+  utility_nav__search: utility_nav__search,
+  utility_nav__link__content: utility_nav__link__content,
+  utility_nav__link__url: utility_nav__link__url,
+  utility_nav__dropdown_link__content: utility_nav__dropdown_link__content,
+  utility_nav__dropdown_link__url: utility_nav__dropdown_link__url,
+  utility_nav__dropdown__items: utility_nav__dropdown__items,
+  menu__contextual: true,
+  directory: directory,
+  primary_nav__content_slot: primary_nav__content_slot,
+  background_image__content_slot: background_image__content_slot,
+} only %}
+  {% block site_header__primary_nav %}{{ primary_nav__content_slot|raw }}{% endblock %}
+  {% block site_header__background_image %}{{ background_image__content_slot|raw }}{% endblock %}
+{% endembed %}
+{% if false %}
+  {% block primary_nav__content %}{% endblock %}
+  {% block background_image__content %}{% endblock %}
+  {% block utility_nav__content %}{% endblock %}
+  {% block site_name_image__content %}{% endblock %}
+{% endif %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -1,25 +1,24 @@
 {#
-  # Available Variables
+  # Render-path adapter for the site header SDC (atomic:site-header, Wave 7 / #1413).
+  #
+  # Available Variables (from atomic_preprocess_region__header + ys_core_preprocess_region)
   # - site_name
-  # - collection_nav_name
-  # - collection_nav_link
-  # - collection_nav_menu_items
-
-  # - header_variant
+  # - header_variant ('normal' | 'in_header')
+  # - collection_nav_name, collection_nav_link, collection_nav_menu_items (in_header only)
+  # - utility_nav__dropdown__items (flattened dropdown menu tree)
+  # - utility_nav__search, utility_nav__link__content, utility_nav__link__url
+  # - site_header__background_image (focus header responsive image, front page only)
   #
   # @see atomic_preprocess_region__header()
+  # @see ys_core_preprocess_region()
 #}
 
 {{ elements.alert_block }}
 
-{% if getHeaderSetting('site_name_image') %}
-  {% set isSiteHeaderLogo = TRUE %}
-  {% set site_header__site_name_image = getHeaderSetting('site_name_image') %}
-{% endif %}
-
-{# Dropdown button links in utility navigation #}
+{# Dropdown button links in utility navigation. #}
 {% set utility_nav_button_title = getHeaderSetting('dropdown_button_title') %}
-{% set utility_nav__dropdown__items = drupal_menu('utility-drop-button-navigation')['#items'] %}
+{% set utility_nav__dropdown_link__content = null %}
+{% set utility_nav__dropdown_link__url = null %}
 {% if utility_nav_button_title and utility_nav__dropdown__items %}
   {{ attach_library('atomic/utility-nav-dropdown-menu') }}
   {% set utility_nav__dropdown_link__content = utility_nav_button_title %}
@@ -27,19 +26,13 @@
 {% endif %}
 
 {#
-  Collection primary nav headers use the same header theme as configured in
-  theme settings. The header_theme setting applies consistently across all
-  pages, including those using collection primary navigation.
-#}
-
-{#
   The header config map has 2 values "normal" and "in_header".
 
   normal - Used for most pages, including regular collection pages.
   in_header - Used only for collections with primary navigation.
 
-  This config allows us to use a single "yds-site-header" template and reassign
-  keys on the left, to different values based on the header_variant.
+  Collection primary nav headers use the same header theme as configured in theme
+  settings, so header_theme applies consistently across all pages.
 #}
 {% set header_config_map = {
   'normal': {
@@ -53,28 +46,31 @@
     'collection_nav_position': 'in_header',
   }
 } %}
-
-{# Use header_header_variant to get correct config_map. #}
 {% set header_config = header_config_map[header_variant] %}
 
-{% embed "@organisms/site-header/yds-site-header.twig" with {
+{% set is_focus_header = getHeaderSetting('header_variation') == 'focus' %}
+
+{% embed 'atomic:site-header' with {
   site_header__site_name: site_name,
   site_header__site_link: '/',
   site_header__collection_nav_name: header_config['collection_nav_name'],
   site_header__collection_nav_link: header_config['collection_nav_link'],
+  site_header__collection_nav_position: header_config['collection_nav_position'],
   site_header__branding_name: getHeaderSetting('site_wide_branding_name'),
   site_header__branding_link: getHeaderSetting('site_wide_branding_link'),
-
-  site_header__collection_nav_position: header_config['collection_nav_position'],
-
   site_header__border_thickness: '8',
   site_header__theme: header_config['header_theme'],
   site_header__accent: getThemeSetting('header_accent'),
   site_header__menu__variation: getHeaderSetting('header_variation'),
   site_header__nav_position: getHeaderSetting('nav_position'),
-  drupal_utility_nav: elements.utility_navigation,
+  utility_nav__search: utility_nav__search|default(null),
+  utility_nav__link__content: utility_nav__link__content|default(null),
+  utility_nav__link__url: utility_nav__link__url|default(null),
+  utility_nav__dropdown_link__content: utility_nav__dropdown_link__content,
+  utility_nav__dropdown_link__url: utility_nav__dropdown_link__url,
+  utility_nav__dropdown__items: utility_nav__dropdown__items|default([]),
 } %}
-  {% block site_header__primary_nav %}
+  {% block primary_nav__content %}
     {% if header_variant == 'in_header' %}
       {% include "@organisms/menu/primary-nav/yds-primary-nav.twig" with {
         primary_nav__items: collection_nav_menu_items,
@@ -85,9 +81,15 @@
     {% endif %}
   {% endblock %}
 
-  {% block site_header__background_image %}
-    {% if site_header__background_image %}
-      {{ site_header__background_image }}
-    {% endif %}
-  {% endblock %}
+  {#
+    background_image__content and site_name_image__content are captured by the SDC
+    and used as truthiness flags in the organism (they toggle the with-background-image
+    and site-name-is-image data attributes), so they must render truly EMPTY when
+    absent — hence whitespace-tight blocks, no surrounding newlines.
+  #}
+  {% block background_image__content %}{% if is_focus_header and site_header__background_image %}{{ site_header__background_image }}{% endif %}{% endblock %}
+
+  {% block utility_nav__content %}{{ elements.utility_navigation }}{% endblock %}
+
+  {% block site_name_image__content %}{% if getHeaderSetting('site_name_image') %}{{ getHeaderSetting('site_name_image')|raw }}{% endif %}{% endblock %}
 {% endembed %}

--- a/tests/src/Unit/SdcSchemaValidationTest.php
+++ b/tests/src/Unit/SdcSchemaValidationTest.php
@@ -635,4 +635,43 @@ class SdcSchemaValidationTest extends UnitTestCase {
     $this->assertNotEmpty($this->validate('in-this-section', ['site_section_wrap__theme' => 'one']));
   }
 
+  /**
+   * Site header: the global chrome header (Wave 7 / #1413).
+   */
+  public function testSiteHeaderValid(): void {
+    $this->assertSame([], $this->validate('site-header', [
+      'site_header__site_name' => 'Yale University',
+      'site_header__site_link' => '/',
+      'site_header__branding_name' => 'Yale University',
+      'site_header__branding_link' => 'https://www.yale.edu',
+      'site_header__border_thickness' => '8',
+      'site_header__theme' => 'three',
+      'site_header__accent' => 'one',
+      'site_header__menu__variation' => 'mega',
+      'site_header__nav_position' => 'left',
+      'utility_nav__search' => 1,
+      'utility_nav__dropdown_link__content' => 'Quick Links',
+      'utility_nav__dropdown_link__url' => '#',
+      'utility_nav__dropdown__items' => [
+        ['title' => 'Faculty', 'url' => '/about-us', 'is_active' => FALSE],
+        [
+          'title' => 'Students',
+          'url' => '/posts',
+          'below' => [['title' => 'News', 'url' => '/posts']],
+        ],
+      ],
+    ]));
+    // The dials are nullable (getThemeSetting/getHeaderSetting can return
+    // NULL); the header must not white-screen when they do.
+    $this->assertSame([], $this->validate('site-header', [
+      'site_header__theme' => NULL,
+      'site_header__menu__variation' => NULL,
+      'utility_nav__search' => NULL,
+    ]));
+    // A wrong-typed search flag (neither bool/int nor null) fails predictably.
+    $this->assertNotEmpty($this->validate('site-header', [
+      'utility_nav__search' => ['unexpected'],
+    ]));
+  }
+
 }


### PR DESCRIPTION
## [1413: Wave 7: Site header SDC conversion](https://github.com/yalesites-org/YaleSites-Internal/issues/1413)

### Description of work
- Convert the global site header (the `region--header` render path and the `@organisms/site-header` organism) to an `atomic:site-header` Single Directory Component thin-wrapper, following the Wave 7 chrome pattern (mirrors the already-converted footer / primary-nav / utility-nav SDCs). Rendered output is byte-identical to the pre-SDC header.
- Flatten the utility drop-button menu tree in `atomic_preprocess_region__header` (via the existing `_atomic_flatten_menu_items()`, converting `\Drupal\Core\Url` objects to string URLs) so it can cross the SDC prop boundary; rendered with `menu__contextual: true`.
- Because an SDC isolates its render context (unlike the previous non-`only` embed), every value the organism and its nested utility-nav include consumed via context inheritance is threaded here as an explicit prop or a markup-captured slot (primary nav, background image, utility nav, site-name image).
- Add a `site-header` schema-validation case to `SdcSchemaValidationTest` (`composer test:sdc`: 51 -> 52 green).
- Design **option A** (no `component-library-twig` change) — this PR is **atomic-only**.
- One intentional, invisible difference: on the focus variant's front page, the indentation of the closing `</div>` of the aria-hidden decorative background-image container differs by whitespace only (the `<img>` itself is byte-identical). This is inherent to the slot-as-truthiness design and has no visual/semantic/a11y impact.
- Other work completed in: yalesites-org/yalesites-project#1379 (multidev-only companion — no yalesites-project changes)
- Builds on yalesites-org/YaleSites-Internal#1362 (atomic PR yalesites-org/atomic#488) — this branch is stacked on that Wave 7 chrome work; please review/approve that PR first.

### Functional testing steps:
- [ ] The site header renders through `atomic:site-header` on every page; no new watchdog errors; `composer test:sdc` is green.
- [ ] Header output is unchanged vs the pre-SDC header for each variant: normal, mega, focus (with and without a background image), utility search enabled, utility dropdown (with a "dropdown button title" + links in the "Utility Drop Button Navigation" menu), and site-name-as-image.
- [ ] On a collection page whose primary nav is positioned "in header", the in-header collection nav + branding render correctly. (Not reproducible on local Lando — the in-header path did not trigger for a hand-made collection on either the pre-SDC or SDC build, so verify on multidev with a real in-header collection.)
- [ ] A CAS-protected utility menu link still renders with its CAS treatment.

References yalesites-org/YaleSites-Internal#1413

---
Created with AI

