### PR TITLE
998: Optimize Gallery Block Image Loading and File Size Limits

### DIFF
--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -6,7 +6,7 @@
     } %}
       {% block media_grid_item__media %}
         {% if (item.entity.field_media.0.entity.mid != NULL) %}
-          {{ drupal_entity('media', item.entity.field_media.0.entity.mid.value, 'card_secondary_3_2') }}
+          {{ drupal_entity('media', item.entity.field_media.0.entity.mid.value, 'gallery_thumbnail') }}
         {% else %}
           {% include "@atoms/images/image/_image.twig" %}
         {% endif %}


### PR DESCRIPTION
## [998: Optimize Gallery Block Image Loading and File Size Limits](https://github.com/yalesites-org/YaleSites-Internal/issues/998)

### Description of work
- Switch the gallery grid thumbnail in `templates/paragraphs/_gallery-item.twig` from the shared `card_secondary_3_2` media view mode to the new gallery-only `gallery_thumbnail` view mode, so gallery thumbnails can load lazily without changing the loading behavior of post cards, custom cards, and other components that share `card_secondary_3_2`.
- **Single work unit with the companion yalesites-project PR** — this twig change depends on the `gallery_thumbnail` media view mode and display defined there, so the two must be reviewed and merged together.
- Other work completed in: yalesites-org/yalesites-project#1374, yalesites-org/component-library-twig#668

### Functional testing steps:
- [ ] On a page with a Gallery block, inspect a gallery thumbnail `<img>` — it renders with `loading="lazy"` and the `3_2_*` (`card_secondary_3_2`) responsive derivatives.
- [ ] The gallery grid looks identical to before — only the loading attribute changed (same crop and size).
- [ ] Post cards and other components using `card_secondary_3_2` are unchanged (still eager).

References yalesites-org/YaleSites-Internal#998

---
Created with AI

