### PR TITLE
1455: Bold text not visually shown inside CKEditor while editing (renders correctly on page)

### DIFF
--- a/css/ckeditor5.css
+++ b/css/ckeditor5.css
@@ -8,8 +8,11 @@
   color: var(--gin-bg-green);
 }
 
-div[contenteditable="true"] .ck-anchor, 
-div[contenteditable="true"] #drupal-off-canvas [data-drupal-ck-style-fence] .ck-anchor {
+div[contenteditable="true"] .ck-anchor,
+div[contenteditable="true"]
+  #drupal-off-canvas
+  [data-drupal-ck-style-fence]
+  .ck-anchor {
   color: var(--gin-bg-green) !important;
   text-decoration: underline;
 }
@@ -20,9 +23,9 @@ div[contenteditable="true"] #drupal-off-canvas [data-drupal-ck-style-fence] .ck-
 }
 
 /* Removes the border style in code blocks within ckeditor */
- .ck-content pre code {
-   border: 0;
- }
+.ck-content pre code {
+  border: 0;
+}
 
 .glb-table .ck-content * {
   padding: 0;
@@ -64,7 +67,9 @@ div[contenteditable="true"] #drupal-off-canvas [data-drupal-ck-style-fence] .ck-
   color: black !important;
 }
 
-#drupal-off-canvas-wrapper .ui-dialog-content div:not([data-drupal-ck-style-fence] *) {
+#drupal-off-canvas-wrapper
+  .ui-dialog-content
+  div:not([data-drupal-ck-style-fence] *) {
   width: 100%;
   max-width: 100%;
 }
@@ -75,4 +80,19 @@ div[contenteditable="true"] #drupal-off-canvas [data-drupal-ck-style-fence] .ck-
 */
 .gin--dark-mode .ck-widget.table table td.ck-editor__nested-editable:focus {
   color: black;
+}
+
+/*
+ * Make bold visually apparent inside the editing surface. The editor renders in
+ * a fallback font stack (Helvetica/Arial) that has no distinct 500 weight, so a
+ * <strong> styled at the front-end mallory-medium weight (500) rounds to normal
+ * and looks unbolded while editing -- even though it renders correctly on the
+ * published page, where Mallory (which has a real 500) is loaded. Force an
+ * unambiguous bold weight in the editor only so editors get immediate visual
+ * confirmation. Italic and other style-based formatting already render in the
+ * fallback font and are unaffected. See yalesites-org/YaleSites-Internal#1455.
+ */
+.ck-content strong,
+.ck-content b {
+  font-weight: 700;
 }


### PR DESCRIPTION
## [1455: Bold text not visually shown inside CKEditor while editing (renders correctly on page)](https://github.com/yalesites-org/YaleSites-Internal/issues/1455)

### Description of work
- Bold applied in a CKEditor 5 editor rendered correctly on the published page but did **not** appear visually bold inside the editing surface, so editors got no visual confirmation of the formatting they applied.
- Root cause (confirmed locally): the editor's `.ck-content` renders in a fallback font stack (`Helvetica, Arial, Tahoma, Verdana, sans-serif`) that has no distinct 500 weight. CKEditor bold produces `<strong>`, which the front-end mallory-medium rule styles at `font-weight: 500`; in the fallback font 500 rounds to 400 and looks unbolded. On the published page Mallory (which has a real 500) is loaded, so it renders correctly there.
- Added an editor-only rule to `css/ckeditor5.css` forcing `font-weight: 700` for `strong`/`b` inside `.ck-content`, so bold is unambiguously visible while editing. The rule is loaded via the theme's `ckeditor5-stylesheets` key, so it affects **only** the editor, never the published page.
- Confirmed which formats were affected: only weight-based formatting (bold). Italic and other style-based formatting already render in the fallback font and are unaffected.
- Product/visual note for the reviewer: the editor bold is set to `700` (unambiguously bold) rather than the page's `500` (mallory-medium), because the editor's fallback font cannot render 500 as distinct from 400. Matching the page's exact 500 would require loading the Mallory web font into the editor (a larger change). Flagging in case exact fidelity is preferred.
- A few pre-existing lines in the same file were normalized by prettier (whitespace/wrapping only, matching the repo's prettier config) — no behavior change.
- Other work completed in: yalesites-org/yalesites-project#1406

### Functional testing steps:
- [ ] Edit any content with a CKEditor field (e.g. a Custom Cards block's "Custom Card Content", or a Text block).
- [ ] Select text and apply **Bold** — confirm the text now appears visually bold inside the editor (previously only the toolbar button toggled).
- [ ] Apply **Italic** — confirm it still renders italic.
- [ ] Save/preview and confirm the published page still renders bold as before (unchanged).

References yalesites-org/YaleSites-Internal#1455

---
Created with AI
