### PR TITLE
697: Add Icon Options to In-Line Message Block

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -401,3 +401,17 @@ th.field-label {
 #block-yalesitesfooterblock .contextual-region {
   display: none;
 }
+
+/*
+ * Let an open Chosen dropdown escape the block-configuration form wrapper.
+ *
+ * gin_lb sets `overflow: auto` on .glb-canvas-form__settings so it scrolls as a
+ * flex child, but our `flex-grow: unset` above makes it content-sized, so that
+ * overflow never scrolls -- it only clips. It was cutting off Chosen's
+ * absolutely-positioned dropdown on short forms such as In-Line Message, where
+ * the Icon picker sits near the end of the form. The :has() guard limits this
+ * to the moment a dropdown is open, so no other form behavior changes.
+ */
+.glb-canvas-form__settings:has(.chosen-with-drop) {
+  overflow: visible;
+}

--- a/templates/block/layout-builder/block--inline-block--inline-message.html.twig
+++ b/templates/block/layout-builder/block--inline-block--inline-message.html.twig
@@ -16,5 +16,6 @@
     inline_message__link__content: content.field_link.0['#title'],
     inline_message__link__url: content.field_link.0['#url_title'],
     inline_message__theme: content.field_style_color.0['#markup'],
+    inline_message__icon_name: content.field_icon.0['#markup'],
   } %}
 {% endblock %}


### PR DESCRIPTION
## [697: Add Icon Options to In-Line Message Block](https://github.com/yalesites-org/YaleSites-Internal/issues/697)

### Description of work
- Pass the In-Line Message block's `field_icon` value (rendered by the `list_key` formatter as the icon machine name) to the component's `inline_message__icon_name` variable, so an editor's chosen icon renders on the block.
- Other work completed in: yalesites-org/component-library-twig#670
- Other work completed in: yalesites-org/yalesites-project#1407

### Functional testing steps:
- [ ] In Layout Builder, add/edit an In-Line Message block, choose an icon, and save; confirm the chosen icon renders beside the message on the page.
- [ ] Choose "- None -" and save; confirm the message renders with no icon.

References yalesites-org/YaleSites-Internal#697

---
Created with AI


### Review round 2 — Chosen dropdown clipping fix

`css/layout-builder.css` now lets an open Chosen dropdown escape the block-configuration form wrapper:

```css
.glb-canvas-form__settings:has(.chosen-with-drop) {
  overflow: visible;
}
```

`gin_lb` sets `overflow: auto` on that wrapper to scroll it as a flex child, but this theme's existing `flex-grow: unset` override makes it content-sized, so the overflow never scrolls and only clips — cutting 216px off the 240px option list on short forms such as In-Line Message. The `:has()` guard limits the change to the moment a dropdown is open.

### Additional functional testing steps:
- [ ] In Layout Builder, configure an **In-Line Message** block and open the **Icon** picker; confirm the dropdown is no longer cut off below the field and the full option list can be scrolled and selected from.
- [ ] Confirm the **Facts and Figures** icon picker still behaves as before.
- [ ] Open another Layout Builder block configuration form and confirm form scrolling is unchanged.

Full write-up on yalesites-org/yalesites-project#1407.
