### PR TITLE
190: Add Block Cloning Functionality

### DIFF
--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -16,23 +16,29 @@
 {% elseif item_variation == 'modal' %}
 
 {#
-  Note: The below check for 'not iterable' is what prevents an error when
-  duplicating paragraphs or attempting to preview modal contents of a newly
-  created paragraph prior to save. This is because the paragraph ID has not
-  yet been created and so cannot be passed to the twig_tweak function.
+  Note: The modal renders the referenced paragraph from the in-memory entity
+  rather than re-loading it by ID. A paragraph that has not been saved yet has
+  no ID, so a load-by-ID lookup returned nothing and the modal came up empty --
+  which is what left cloned and brand-new gallery blocks without their enlarged
+  images in the Layout Builder preview.
+
+  The entity type is checked first because 'item.entity' does not fail closed:
+  when the reference is dangling, Twig falls through to FieldItemBase::getEntity()
+  and hands back the HOST gallery block, which would otherwise be rendered
+  inside every modal slot.
 #}
 
   {% embed "@organisms/galleries/media-grid/_yds-media-grid-modal-item.twig" with {
     media_grid__items: content.field_gallery_items['#items'],
   } %}
     {% block media_grid__modal__media %}
-      {% if item.entity.id.0.value is not iterable %}
-        {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_media') }}
+      {% if item.entity.entityTypeId == 'paragraph' %}
+        {{ item.entity|view('gallery_modal_media') }}
       {% endif %}
     {% endblock %}
     {% block media_grid__modal__content %}
-      {% if item.entity.id.0.value is not iterable %}
-        {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_content') }}
+      {% if item.entity.entityTypeId == 'paragraph' %}
+        {{ item.entity|view('gallery_modal_content') }}
       {% endif %}
     {% endblock %}
   {% endembed %}


### PR DESCRIPTION
## [190: Add Block Cloning Functionality](https://github.com/yalesites-org/YaleSites-Internal/issues/190)

### Description of work
- Theme-side half of block cloning. Resolves acceptance criterion 5: *"media references in cloned paragraphs (e.g. Gallery block) don't display in Layout Builder preview."*
- The gallery modal re-loaded each referenced paragraph **by ID** (`drupal_entity('paragraph', item.entity.id.0.value, ...)`). A paragraph that has not been saved yet has no ID, so the lookup returned nothing and the modal came up empty. That is why a freshly cloned gallery block showed its grid thumbnails but no enlarged images in the Layout Builder preview. It affected any unsaved gallery paragraph, including a brand-new one before its first save — cloning just made it easy to hit.
- Renders the **in-memory entity** with twig_tweak's `|view()` filter instead, so saved and unsaved paragraphs both work.
- **Access checking is unchanged.** Both `drupal_entity()` and `|view()` default to `check_access = TRUE` and call the same `twig_tweak.entity_view_builder`, which runs `$entity->access('view')` before building. Cache metadata is attached by that same builder, so it is identical too.
- Adds an entity-type guard, which also fixes a latent bug in the old code. `item.entity` does **not** fail closed: when the reference is dangling, Twig falls through to `FieldItemBase::getEntity()` and hands back the **host** gallery block. The old code then passed that block's ID through as a *paragraph* ID, rendering an unrelated paragraph into the modal. The guard skips the slot instead.
- Side effect worth noting: `drupal_entity()` loaded the paragraph's **default** revision, whereas `item.entity` resolves the pinned `target_revision_id`. Older node revisions now render the gallery revision they actually pinned rather than current content.
- Other work completed in: yalesites-org/yalesites-project#1408

### Functional testing steps:
- [ ] Edit the layout of a page containing a **Gallery** block.
- [ ] Open the gallery block's contextual menu (gear icon) and choose **Clone block**.
- [ ] Confirm the cloned gallery appears directly after the original **with its grid thumbnails**.
- [ ] Confirm the clone's **modal / lightbox images and captions are present** in the preview (before this change the cloned gallery's modal was empty).
- [ ] Save the layout, view the published page, and open the cloned gallery's lightbox — the enlarged images and captions should match the original's.
- [ ] Confirm an existing, already-saved gallery still renders its lightbox correctly on the published page (no regression).
- [ ] Add a **brand-new** Gallery block, add media, and confirm the modal previews before the first save.

References yalesites-org/YaleSites-Internal#190