### PR TITLE
1435: Update Storybook to latest version and move to Vite

### DIFF
--- a/atomic.libraries.yml
+++ b/atomic.libraries.yml
@@ -9,9 +9,9 @@ global:
       css/views-empty-state.css: {}
       node_modules/@yalesites-org/component-library-twig/dist/css/link-treatment.css: {}
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/menu/menu-toggle/yds-menu-toggle.js: {}
-    node_modules/@yalesites-org/component-library-twig/dist/js/00-tokens/layout/yds-layout.js: {}
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/tables/table.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/menu/menu-toggle/yds-menu-toggle.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/00-tokens/layout/yds-layout.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/01-atoms/tables/table.js: {}
     node_modules/@yalesites-org/component-library-twig/dist/js/link-treatment.js: {}
   dependencies:
     - core/drupal
@@ -20,34 +20,34 @@ disable-menu:
     js/disable-menu.js: {}
 accordion:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/accordion/yds-accordion.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/accordion/yds-accordion.js: {}
 alert:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/alert/yds-alert.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/alert/yds-alert.js: {}
 primary-nav:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/primary-nav/yds-primary-nav.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/03-organisms/menu/primary-nav/yds-primary-nav.js: {}
 secondary-nav:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/secondary-nav/yds-secondary-nav.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/03-organisms/menu/secondary-nav/yds-secondary-nav.js: {}
 reference-card:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/cards/reference-card/yds-reference-card.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/cards/reference-card/yds-reference-card.js: {}
 custom-card:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/cards/custom-card/yds-custom-card.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/cards/custom-card/yds-custom-card.js: {}
 breadcrumbs:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/breadcrumbs/yds-breadcrumbs.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/03-organisms/menu/breadcrumbs/yds-breadcrumbs.js: {}
 tabs:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/tabs/yds-tabs.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/tabs/yds-tabs.js: {}
 gallery:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/galleries/media-grid/yds-media-grid-interactive.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/03-organisms/galleries/media-grid/yds-media-grid-interactive.js: {}
 background-video:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/videos/video-background/yds-video-background.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/01-atoms/videos/video-background/yds-video-background.js: {}
 fontawesome:
   css:
     theme:
@@ -60,41 +60,41 @@ layout-builder:
       css/layout-builder.css: {}
 text-link:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/controls/text-link/yds-text-link.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/01-atoms/controls/text-link/yds-text-link.js: {}
 text:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/typography/text/yds-text.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/01-atoms/typography/text/yds-text.js: {}
 text-copy-button:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/controls/text-copy-button/yds-text-copy-button.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/01-atoms/controls/text-copy-button/yds-text-copy-button.js: {}
 event-localist:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/meta/event-meta/event-meta-localist.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/meta/event-meta/event-meta-localist.js: {}
 chosen-select:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/forms/select/yds-select.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/01-atoms/forms/select/yds-select.js: {}
   dependencies:
     - core/once
     - libraries/chosen
 calendar:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/calendar/yds-calendar.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/03-organisms/calendar/yds-calendar.js: {}
   dependencies:
     - core/drupal
     - core/drupal.ajax
 audio-player:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/01-atoms/audio/yds-audio-player.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/01-atoms/audio/yds-audio-player.js: {}
 in-this-section:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/menu/menu-in-this-section-toggle/yds-menu-in-this-section-toggle.js: {}
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/site-in-this-section/yds-site-in-this-section.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/menu/menu-in-this-section-toggle/yds-menu-in-this-section-toggle.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/03-organisms/site-in-this-section/yds-site-in-this-section.js: {}
 utility-nav-dropdown-menu:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/03-organisms/menu/utility-nav/utility-nav-dropdown-menu.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/03-organisms/menu/utility-nav/utility-nav-dropdown-menu.js: {}
 ys_embed:
   dependencies:
     - core/jquery
 read-time:
   js:
-    node_modules/@yalesites-org/component-library-twig/dist/js/02-molecules/read-time/yds-read-time.js: {}
+    node_modules/@yalesites-org/component-library-twig/dist/js/components/02-molecules/read-time/yds-read-time.js: {}


### PR DESCRIPTION
## [#1435: Update Storybook to latest version and move to Vite (via Emulsify update)](https://github.com/yalesites-org/YaleSites-Internal/issues/1435)

### Description of work
- Updates every `dist/js/<tier>/...` library reference in `atomic.libraries.yml` to the new `dist/js/components/<tier>/...` path
- `dist/css/style.css`, `dist/css/link-treatment.css`, and the FontAwesome CSS paths are unchanged as the component-library-twig's build was patched to keep emitting those at their original locations

### Functional testing steps:
- [ ] No standalone testing here as this is a path-only change with nothing to render on its own. Verify it alongside the matching [component-library-twig](https://github.com/yalesites-org/component-library-twig/pull/672) and [yalesites-project](https://github.com/yalesites-org/yalesites-project/pull/1413) branches via the multidev preview