### PR TITLE
190: Render the gallery modal from the paragraph entity instead of by ID - Alternative

### DIFF
--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -16,23 +16,25 @@
 {% elseif item_variation == 'modal' %}
 
 {#
-  Note: The below check for 'not iterable' is what prevents an error when
-  duplicating paragraphs or attempting to preview modal contents of a newly
-  created paragraph prior to save. This is because the paragraph ID has not
-  yet been created and so cannot be passed to the twig_tweak function.
+  Note: the paragraph is rendered from the entity object (the twig_tweak `view`
+  filter) rather than by ID (`drupal_entity('paragraph', id, ...)`). An unsaved
+  paragraph — a newly added gallery item, or one belonging to a block that was
+  just cloned in Layout Builder — has no ID yet, so rendering by ID silently
+  produced an empty modal in the Layout Builder preview even though the media
+  reference was there.
 #}
 
   {% embed "@organisms/galleries/media-grid/_yds-media-grid-modal-item.twig" with {
     media_grid__items: content.field_gallery_items['#items'],
   } %}
     {% block media_grid__modal__media %}
-      {% if item.entity.id.0.value is not iterable %}
-        {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_media') }}
+      {% if item.entity %}
+        {{ item.entity|view('gallery_modal_media') }}
       {% endif %}
     {% endblock %}
     {% block media_grid__modal__content %}
-      {% if item.entity.id.0.value is not iterable %}
-        {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_content') }}
+      {% if item.entity %}
+        {{ item.entity|view('gallery_modal_content') }}
       {% endif %}
     {% endblock %}
   {% endembed %}


### PR DESCRIPTION
## [190: Add Block Cloning Functionality](https://github.com/yalesites-org/YaleSites-Internal/issues/190)

### Description of work
- `templates/paragraphs/_gallery-item.twig` rendered the lightbox contents with
  `drupal_entity('paragraph', item.entity.id.0.value, ...)`, which needs a **saved**
  paragraph ID. An unsaved paragraph has none, so the modal came out empty in the Layout
  Builder preview even though the media reference was present and the canonical node route
  was fine.
- Now renders from the entity object via twig_tweak's `view` filter, which takes an
  `EntityInterface` and keeps the same `check_access` default — no access change.
- This affected **any** unsaved gallery item, not only cloned ones: adding a gallery item and
  previewing before save hit the same empty modal. The old `is not iterable` guard was
  suppressing the error rather than fixing the cause.
- **Single work unit with the companion yalesites-project PR** — that PR adds the Clone
  option that makes this reachable, and it carries the matching branch name that
  `build_frontend` needs to swap this branch into the multidev.
- Other work completed in: yalesites-org/yalesites-project#1414

### Functional testing steps:
- [ ] On a page with a Gallery block, open the block in Layout Builder and confirm the grid thumbnails still look identical to before
- [ ] Click a thumbnail and confirm the lightbox opens with the full image and its caption/heading
- [ ] Add a **new** gallery item and, **before saving**, open its lightbox from the Layout Builder preview — the image should now appear (previously blank)
- [ ] Clone a Gallery block (companion PR) and confirm the copy's lightbox shows the right images in the preview
- [ ] View the page on the canonical route (not Layout Builder) and confirm the gallery and lightbox are unchanged

References yalesites-org/YaleSites-Internal#190

---
Created with AI
