### PR TITLE
Bump component library twig to v1.80.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,9 +2087,9 @@
       "inBundle": true
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.79.2",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.79.2/fd6651a4671b367b3802c0db10ef210e7d5884da",
-      "integrity": "sha512-OB0BW+dh+HxzIPOBUyLoPLSSwGCaRXXdMdwFiBIEXx2GPPvJ+ZeShGR6zG6oVbnvmeRkcR4htwPQ8CeKm6e59Q==",
+      "version": "1.80.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.80.0/f1df0698f6e1f5ffb2dbe8f66cd22ca0380e39cc",
+      "integrity": "sha512-Pr9cYFwpSpZJmeV/nqpxGBr53FQaYnZbqaiK7tVXkpjqGmkpfZkMTIGNNcgfoI5Mr/ssvAV35AqoaQjYKYLHxw==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {


### PR DESCRIPTION
Bumps the `@yalesites-org/component-library-twig` dependency in `package-lock.json` to v1.80.0.

Component library release: https://github.com/yalesites-org/component-library-twig/releases/tag/v1.80.0