### PR TITLE
Bump component library twig to v1.81.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,9 +2087,9 @@
       "inBundle": true
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.80.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.80.0/f1df0698f6e1f5ffb2dbe8f66cd22ca0380e39cc",
-      "integrity": "sha512-Pr9cYFwpSpZJmeV/nqpxGBr53FQaYnZbqaiK7tVXkpjqGmkpfZkMTIGNNcgfoI5Mr/ssvAV35AqoaQjYKYLHxw==",
+      "version": "1.81.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.81.0/588b169dcb4ccafb533fae24c1a3390aa090acde",
+      "integrity": "sha512-aLWuWeDSNBIWYW6N8oHymeKC+lUNl7VT6v4OwhR4v+5EXYIfZ7FjVVd9dFroIThnJpimmQBiFQpP9coHBfMTAA==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {


### PR DESCRIPTION
Bumps the `@yalesites-org/component-library-twig` dependency in `package-lock.json` to v1.81.0.

Component library release: https://github.com/yalesites-org/component-library-twig/releases/tag/v1.81.0