### PR TITLE
RC Update

### DIFF
--- a/css/layout-builder.css
+++ b/css/layout-builder.css
@@ -401,3 +401,17 @@ th.field-label {
 #block-yalesitesfooterblock .contextual-region {
   display: none;
 }
+
+/*
+ * Let an open Chosen dropdown escape the block-configuration form wrapper.
+ *
+ * gin_lb sets `overflow: auto` on .glb-canvas-form__settings so it scrolls as a
+ * flex child, but our `flex-grow: unset` above makes it content-sized, so that
+ * overflow never scrolls -- it only clips. It was cutting off Chosen's
+ * absolutely-positioned dropdown on short forms such as In-Line Message, where
+ * the Icon picker sits near the end of the form. The :has() guard limits this
+ * to the moment a dropdown is open, so no other form behavior changes.
+ */
+.glb-canvas-form__settings:has(.chosen-with-drop) {
+  overflow: visible;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,9 +2087,9 @@
       "inBundle": true
     },
     "node_modules/@yalesites-org/component-library-twig": {
-      "version": "1.80.0",
-      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.80.0/f1df0698f6e1f5ffb2dbe8f66cd22ca0380e39cc",
-      "integrity": "sha512-Pr9cYFwpSpZJmeV/nqpxGBr53FQaYnZbqaiK7tVXkpjqGmkpfZkMTIGNNcgfoI5Mr/ssvAV35AqoaQjYKYLHxw==",
+      "version": "1.81.0",
+      "resolved": "https://npm.pkg.github.com/download/@yalesites-org/component-library-twig/1.81.0/588b169dcb4ccafb533fae24c1a3390aa090acde",
+      "integrity": "sha512-aLWuWeDSNBIWYW6N8oHymeKC+lUNl7VT6v4OwhR4v+5EXYIfZ7FjVVd9dFroIThnJpimmQBiFQpP9coHBfMTAA==",
       "hasInstallScript": true,
       "inBundle": true,
       "dependencies": {

--- a/templates/block/layout-builder/block--inline-block--inline-message.html.twig
+++ b/templates/block/layout-builder/block--inline-block--inline-message.html.twig
@@ -16,5 +16,6 @@
     inline_message__link__content: content.field_link.0['#title'],
     inline_message__link__url: content.field_link.0['#url_title'],
     inline_message__theme: content.field_style_color.0['#markup'],
+    inline_message__icon_name: content.field_icon.0['#markup'],
   } %}
 {% endblock %}

--- a/templates/block/layout-builder/block--inline-block--link-grid.html.twig
+++ b/templates/block/layout-builder/block--inline-block--link-grid.html.twig
@@ -8,11 +8,7 @@
     {% set link_grid__width = "site" %}
   {% endif %}
 
-  {% if layout_section == 'ys_layout_two_column_50_50' %}
-    {% set link_grid_theme = 'inherit' %}
-  {% else %}
-    {% set link_grid_theme = content.field_style_color.0['#markup'] %}
-  {% endif %}
+  {% set link_grid_theme = content.field_style_color.0['#markup'] %}
 
   {# add checks for each link list #}
   {% set link_grid__links_one = content.field_link_lists.0 %}

--- a/templates/form/form-element-label--ys-themes-settings-form--global-theme.html.twig
+++ b/templates/form/form-element-label--ys-themes-settings-form--global-theme.html.twig
@@ -12,8 +12,10 @@
   <label{{ attributes.addClass(classes) }}>
     {{ title }}
     <span class="colors">
-      {% for key,value in getSettingValues('global_theme') %}
-        <span class="color" style="background: var(--global-themes-{{ element['#context']['value'] }}-colors-slot-{{ key }});"></span>
+      {# Six selectable palette colors: slots one–five plus slot-nine (secondary background). #}
+      {% set palette_slots = ['one', 'two', 'three', 'four', 'five', 'nine'] %}
+      {% for slot in palette_slots %}
+        <span class="color" style="background: var(--global-themes-{{ element['#context']['value'] }}-colors-slot-{{ slot }});"></span>
       {% endfor %}
     </span>
   </label>

--- a/templates/paragraphs/_gallery-item.twig
+++ b/templates/paragraphs/_gallery-item.twig
@@ -16,23 +16,29 @@
 {% elseif item_variation == 'modal' %}
 
 {#
-  Note: The below check for 'not iterable' is what prevents an error when
-  duplicating paragraphs or attempting to preview modal contents of a newly
-  created paragraph prior to save. This is because the paragraph ID has not
-  yet been created and so cannot be passed to the twig_tweak function.
+  Note: The modal renders the referenced paragraph from the in-memory entity
+  rather than re-loading it by ID. A paragraph that has not been saved yet has
+  no ID, so a load-by-ID lookup returned nothing and the modal came up empty --
+  which is what left cloned and brand-new gallery blocks without their enlarged
+  images in the Layout Builder preview.
+
+  The entity type is checked first because 'item.entity' does not fail closed:
+  when the reference is dangling, Twig falls through to FieldItemBase::getEntity()
+  and hands back the HOST gallery block, which would otherwise be rendered
+  inside every modal slot.
 #}
 
   {% embed "@organisms/galleries/media-grid/_yds-media-grid-modal-item.twig" with {
     media_grid__items: content.field_gallery_items['#items'],
   } %}
     {% block media_grid__modal__media %}
-      {% if item.entity.id.0.value is not iterable %}
-        {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_media') }}
+      {% if item.entity.entityTypeId == 'paragraph' %}
+        {{ item.entity|view('gallery_modal_media') }}
       {% endif %}
     {% endblock %}
     {% block media_grid__modal__content %}
-      {% if item.entity.id.0.value is not iterable %}
-        {{ drupal_entity('paragraph', item.entity.id.0.value|default(''), 'gallery_modal_content') }}
+      {% if item.entity.entityTypeId == 'paragraph' %}
+        {{ item.entity|view('gallery_modal_content') }}
       {% endif %}
     {% endblock %}
   {% endembed %}


### PR DESCRIPTION
## Included PRs

- [#499: Bump component library twig to v1.81.0](https://github.com/yalesites-org/atomic/pull/499)
- [#494: 190: Add Block Cloning Functionality](https://github.com/yalesites-org/atomic/pull/494)
- [#493: 697: Add Icon Options to In-Line Message Block](https://github.com/yalesites-org/atomic/pull/493)
- [#451: #1153 :: Color palette: remove ONHA if-statement overrides & add 6th color slot system-wide](https://github.com/yalesites-org/atomic/pull/451)