### PR TITLE
1541: Add color theme picker to Two Column (70/30) layout

### DIFF
--- a/css/admin-theme.css
+++ b/css/admin-theme.css
@@ -108,18 +108,21 @@ html.gin--dark-mode form.layout-builder-configure-block.glb-form {
 }
 
 /* two-column layout edit adjustments */
-.yds-two-column .layout-builder-block.contextual-region .contextual {
+.yds-two-column .layout-builder-block.contextual-region .contextual,
+.yds-layout[data-component-layout='seventy-thirty'] .layout-builder-block.contextual-region .contextual {
   left: 0;
 }
 
 @media only screen and (min-width: 2200px) {
-  .yds-two-column .layout-builder-block.contextual-region .contextual {
+  .yds-two-column .layout-builder-block.contextual-region .contextual,
+  .yds-layout[data-component-layout='seventy-thirty'] .layout-builder-block.contextual-region .contextual {
     left: -1vw;
   }
 }
 
 @media only screen and (min-width: 2500px) {
-  .yds-two-column .layout-builder-block.contextual-region .contextual {
+  .yds-two-column .layout-builder-block.contextual-region .contextual,
+  .yds-layout[data-component-layout='seventy-thirty'] .layout-builder-block.contextual-region .contextual {
     left: -1vw;
   }
 }


### PR DESCRIPTION
## [1541: Add color theme picker to Two Column (70/30) layout](https://github.com/yalesites-org/YaleSites-Internal/issues/1541)

Investigating yalesites-org/YaleSites-Internal#1541 (which asked to add a slot-9 color
option to the Layout Section picker) found the ticket's premise was already resolved for
Two Column (50/50) and Three Column (33/33/33) since ticket #1153 — posted evidence on
the issue recommending it be closed/retitled:
https://github.com/yalesites-org/YaleSites-Internal/issues/1541#issuecomment-5286073268

The actual gap: Two Column (70/30) has no "Component theme" picker at all, unlike its
siblings. The yalesites-project companion PR wires it to the existing `YSLayoutOptions`
class and the shared `yds-layout.twig` organism from component-library-twig, giving it
the same picker — including the already-correct slot-9 option.

### Description of work
- Add a matching `.yds-layout[data-component-layout='seventy-thirty']` selector to the
  hand-written admin CSS that positions the Layout Builder contextual-links pencil icon,
  which was previously scoped only to the old `yds-two-column` organism's class name and
  would otherwise be orphaned once 70/30 stops using it.
- Other work completed in: yalesites-org/component-library-twig#687,
  yalesites-org/yalesites-project#1465

### Functional testing steps:
- [ ] In Layout Builder, add a block to a Two Column (70/30) section and confirm the
  contextual-links pencil icon is positioned correctly (not clipped/offset) at various
  viewport widths

References yalesites-org/YaleSites-Internal#1541
